### PR TITLE
Implement S3-backed storage and manifest I/O

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -7,9 +7,26 @@
 | 2 | Scaffold Rust workspace and crate skeletons aligned with the design | Done | Workspace file plus per-crate Cargo manifests and placeholder modules. |
 | 3 | Add repository documentation (README, design doc, AGENTS guidance) | Done | Authored README, captured the design doc verbatim, and wrote repo-wide agent instructions. |
 | 4 | Run baseline tooling (`cargo fmt`, `cargo check`) | Done | Verified formatting and compilation of the newly scaffolded workspace. |
+| 5 | Implement storage adaptor (`S3Store`) and manifest I/O | Done | Backed the `ObjectStore` trait with real AWS SDK calls, added manifest load/publish helpers, and covered the flows with unit tests. |
+| 6 | Build ingest pipeline (quantisation + part builder) | Todo | `quant::{encode_rabitq,score_with_rabitq}` and `part_builder::build_part` need real implementations to generate RaBitQ metadata, write artifacts, and emit statistics per the design doc. |
+| 7 | Flesh out search stack (candidate gen + rerank) | Todo | `index::search_namespace` and `rerank::{rerank_int8,rerank_fp32}` remain placeholders; plan to integrate IVF probing, tombstone handling, and rerank fallbacks. |
+| 8 | Expose HTTP surface & orchestration | Todo | `api::serve` is unimplemented; define Axum routes for namespace CRUD, ingest, search, and manifest debug endpoints, delegating to storage/manifests/search layers. |
+| 9 | Tombstones and compaction workflows | Todo | Implement `bitmap::LiveSet::from_deletes` to materialise roaring sets and `compactor::compact_once` to drive background merging and manifest publication. |
 
 ## Progress Log
 - Initialised planning document to track tasks and their completion.
 - Created workspace structure with placeholder crates covering all subsystems.
 - Documented architecture (README, design doc) and added contributor guidance in AGENTS.md.
 - Executed `cargo fmt` and `cargo check` to ensure the skeleton builds cleanly.
+
+## Outstanding TODO Summary
+- **Ingest Pipeline:** `quant::encode_rabitq`, `quant::score_with_rabitq`, and `part_builder::build_part` are skeletons. Implement RaBitQ encoding, scoring heuristics, IVF training, part artefact assembly, and upload staging per `docs/design.md`.
+- **Search Path:** `index::search_namespace` and the rerank functions (`rerank::rerank_int8`, `rerank::rerank_fp32`) are placeholders; build candidate generation, live-set filtering, and reranking strategies aligned with namespace defaults.
+- **API Surface:** `api::serve` must wire Axum routes for namespace CRUD, ingest, search, and health, coordinating with manifest, storage, and search layers.
+- **Maintenance Jobs:** `bitmap::LiveSet::from_deletes` and `compactor::compact_once` need logic to hydrate roaring bitmaps, apply tombstones, and publish merged parts.
+
+## Next Steps
+1. Implement the ingest pipeline (Step 6), leveraging quantisation kernels to emit parts and manifest entries.
+2. Develop the search and reranking stages (Step 7) using the produced artefacts and tombstone filtering.
+3. Expand the HTTP API and orchestration layer (Step 8) once core workflows are functional.
+4. Close the loop with tombstone application and compaction automation (Step 9) to maintain namespace health.

--- a/crates/manifest/Cargo.toml
+++ b/crates/manifest/Cargo.toml
@@ -11,5 +11,9 @@ serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
 tracing.workspace = true
+bytes.workspace = true
 common = { path = "../common" }
 storage = { path = "../storage" }
+
+[dev-dependencies]
+async-trait.workspace = true

--- a/crates/manifest/src/lib.rs
+++ b/crates/manifest/src/lib.rs
@@ -2,29 +2,127 @@
 
 //! Helpers for reading and publishing manifest snapshots to S3.
 
-use common::{Error, ManifestView, NamespaceConfig, Result};
+use anyhow::Context;
+use bytes::Bytes;
+use common::{Epoch, Error, ManifestView, NamespaceConfig, Result};
+use serde::{Deserialize, Serialize};
 use storage::ObjectStore;
 use tracing::instrument;
 
 /// Name of the object that stores the pointer to the latest manifest epoch.
 pub const CURRENT_MANIFEST_KEY: &str = "manifest/current";
 
+/// Serialised representation of the manifest pointer stored under [`CURRENT_MANIFEST_KEY`].
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct ManifestPointer {
+    epoch: Epoch,
+    etag: String,
+}
+
 /// Fetches the namespace configuration and manifest for the provided namespace identifier.
 #[instrument(skip(store))]
 pub async fn load_manifest(store: &dyn ObjectStore, ns: &str) -> Result<ManifestView> {
-    let _ = store.get(CURRENT_MANIFEST_KEY).await?;
-    Err(Error::Message(format!(
-        "manifest loading is not yet implemented for namespace {ns}"
-    )))
+    let pointer_key = namespace_scoped(ns, CURRENT_MANIFEST_KEY);
+    let pointer_obj = store
+        .get(&pointer_key)
+        .await
+        .with_context(|| format!("failed to fetch manifest pointer for namespace {ns}"))?;
+
+    let pointer: ManifestPointer = serde_json::from_slice(&pointer_obj.data)
+        .with_context(|| format!("manifest pointer for namespace {ns} was malformed"))?;
+
+    let manifest_key = manifest_epoch_key(ns, pointer.epoch);
+    let manifest_obj = store.get(&manifest_key).await.with_context(|| {
+        format!(
+            "failed to fetch manifest epoch {} for namespace {ns}",
+            pointer.epoch
+        )
+    })?;
+
+    if let Some(etag) = manifest_obj.etag.as_deref() {
+        if etag != pointer.etag {
+            return Err(Error::Message(format!(
+                "manifest etag mismatch for namespace {ns}: pointer expected {} but object reported {}",
+                pointer.etag, etag
+            )));
+        }
+    }
+
+    let view: ManifestView = serde_json::from_slice(&manifest_obj.data)
+        .with_context(|| format!("manifest epoch {} could not be parsed", pointer.epoch))?;
+
+    if view.epoch != pointer.epoch {
+        return Err(Error::Message(format!(
+            "manifest epoch mismatch for namespace {ns}: pointer references {} but payload was {}",
+            pointer.epoch, view.epoch
+        )));
+    }
+
+    Ok(view)
 }
 
 /// Writes a new manifest epoch and atomically flips the current pointer.
 #[instrument(skip(store, view))]
-pub async fn publish_manifest(store: &dyn ObjectStore, view: &ManifestView) -> Result<()> {
-    let _ = (store, view);
-    Err(Error::Message(
-        "manifest publication is not yet implemented".to_string(),
-    ))
+pub async fn publish_manifest(
+    store: &dyn ObjectStore,
+    ns: &str,
+    view: &ManifestView,
+) -> Result<()> {
+    validate_namespace(&view.namespace)?;
+
+    let pointer_key = namespace_scoped(ns, CURRENT_MANIFEST_KEY);
+    let pointer_obj = store
+        .get(&pointer_key)
+        .await
+        .with_context(|| format!("failed to fetch existing manifest pointer for namespace {ns}"))?;
+
+    let current_pointer: ManifestPointer = serde_json::from_slice(&pointer_obj.data)
+        .with_context(|| format!("manifest pointer for namespace {ns} was malformed"))?;
+
+    if view.epoch <= current_pointer.epoch {
+        return Err(Error::Message(format!(
+            "refusing to publish stale manifest for namespace {ns}: {} <= {}",
+            view.epoch, current_pointer.epoch
+        )));
+    }
+
+    let manifest_key = manifest_epoch_key(ns, view.epoch);
+    let manifest_bytes = serde_json::to_vec(view).map(Bytes::from).with_context(|| {
+        format!(
+            "failed to serialise manifest epoch {} for namespace {ns}",
+            view.epoch
+        )
+    })?;
+    let manifest_etag = store
+        .put(&manifest_key, manifest_bytes)
+        .await
+        .with_context(|| {
+            format!(
+                "failed to persist manifest epoch {} for namespace {ns}",
+                view.epoch
+            )
+        })?;
+
+    let Some(pointer_etag) = pointer_obj.etag.as_deref() else {
+        return Err(Error::Message(format!(
+            "no etag was returned for manifest pointer of namespace {ns}; cannot perform conditional update"
+        )));
+    };
+
+    let new_pointer = ManifestPointer {
+        epoch: view.epoch,
+        etag: manifest_etag,
+    };
+    let pointer_bytes = serde_json::to_vec(&new_pointer)
+        .map(Bytes::from)
+        .with_context(|| format!("failed to serialise manifest pointer for namespace {ns}"))?;
+
+    store
+        .put_if_match(&pointer_key, pointer_bytes, pointer_etag)
+        .await
+        .with_context(|| format!("failed to update manifest pointer for namespace {ns}"))?;
+
+    Ok(())
 }
 
 /// Validates a namespace configuration before it is persisted.
@@ -36,4 +134,218 @@ pub fn validate_namespace(cfg: &NamespaceConfig) -> Result<()> {
         return Err(Error::from("cluster factor must be within a sane range"));
     }
     Ok(())
+}
+
+fn namespace_scoped(ns: &str, suffix: &str) -> String {
+    format!("namespaces/{ns}/{suffix}")
+}
+
+fn manifest_epoch_key(ns: &str, epoch: Epoch) -> String {
+    namespace_scoped(ns, &format!("manifest/{epoch}.json"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use bytes::Bytes;
+    use common::{
+        DeletePartId, DeletePartKind, DeletePartMetadata, DeletePartPaths, ManifestView,
+        NamespaceConfig, NamespaceDefaults, PartId, PartMetadata, PartPaths, PartStatistics,
+    };
+    use std::collections::HashMap;
+    use std::sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    };
+    use storage::ObjectBytes;
+    use tokio::sync::Mutex;
+
+    #[derive(Clone, Debug)]
+    struct StoredObject {
+        data: Bytes,
+        etag: String,
+    }
+
+    #[derive(Clone, Default, Debug)]
+    struct InMemoryStore {
+        objects: Arc<Mutex<HashMap<String, StoredObject>>>,
+        counter: Arc<AtomicU64>,
+    }
+
+    impl InMemoryStore {
+        fn next_etag(&self) -> String {
+            let value = self.counter.fetch_add(1, Ordering::SeqCst) + 1;
+            format!("\"etag-{value}\"")
+        }
+
+        async fn insert(&self, key: &str, data: Bytes) -> String {
+            let etag = self.next_etag();
+            let object = StoredObject {
+                data,
+                etag: etag.clone(),
+            };
+            self.objects.lock().await.insert(key.to_string(), object);
+            etag
+        }
+    }
+
+    #[async_trait]
+    impl ObjectStore for InMemoryStore {
+        async fn get(&self, key: &str) -> Result<ObjectBytes> {
+            let guard = self.objects.lock().await;
+            let object = guard
+                .get(key)
+                .cloned()
+                .ok_or_else(|| Error::Message(format!("missing key {key}")))?;
+            Ok(ObjectBytes::new(object.data, Some(object.etag)))
+        }
+
+        async fn put(&self, key: &str, data: Bytes) -> Result<String> {
+            Ok(self.insert(key, data).await)
+        }
+
+        async fn put_if_match(&self, key: &str, data: Bytes, if_match: &str) -> Result<String> {
+            let mut guard = self.objects.lock().await;
+            let entry = guard
+                .get_mut(key)
+                .ok_or_else(|| Error::Message(format!("missing key {key}")))?;
+            if entry.etag != if_match {
+                return Err(Error::Message(format!(
+                    "etag mismatch for key {key}: expected {}, found {if_match}",
+                    entry.etag
+                )));
+            }
+            entry.data = data;
+            entry.etag = self.next_etag();
+            Ok(entry.etag.clone())
+        }
+    }
+
+    fn sample_manifest(epoch: Epoch) -> ManifestView {
+        ManifestView {
+            namespace: NamespaceConfig {
+                dim: 128,
+                cluster_factor: 1.0,
+                k_min: 1,
+                k_max: 1024,
+                nprobe_cap: 16,
+                defaults: NamespaceDefaults::recommended(),
+            },
+            parts: vec![PartMetadata {
+                part_id: PartId("p1".to_string()),
+                n: 10,
+                dim: 128,
+                k_trained: 4,
+                small_part_fallback: false,
+                doc_id_range: (0, 10),
+                paths: PartPaths {
+                    centroids: "parts/p1/ivf/centroids.bin".to_string(),
+                    ilist_dir: "parts/p1/ivf/lists/".to_string(),
+                    rabitq_meta: "parts/p1/rabitq/meta.json".to_string(),
+                    rabitq_codes: "parts/p1/rabitq/codes-1bit.bin".to_string(),
+                    vec_int8_dir: "parts/p1/vectors/int8/".to_string(),
+                    vec_fp32_dir: "parts/p1/vectors/fp32/".to_string(),
+                },
+                stats: PartStatistics {
+                    created_at: "2024-01-01T00:00:00Z".to_string(),
+                    mean_norm: 1.0,
+                },
+            }],
+            delete_parts: vec![DeletePartMetadata {
+                del_part_id: DeletePartId("d1".to_string()),
+                kind: DeletePartKind::Bitmap,
+                created_at: "2024-01-02T00:00:00Z".to_string(),
+                paths: DeletePartPaths {
+                    bitmap: Some("deletes/d1/tombstone.bitmap.roaring".to_string()),
+                    ids: None,
+                },
+            }],
+            epoch,
+        }
+    }
+
+    async fn seed_manifest(store: &InMemoryStore, ns: &str, view: &ManifestView) -> Result<()> {
+        let manifest_key = manifest_epoch_key(ns, view.epoch);
+        let manifest_bytes = serde_json::to_vec(view)
+            .map(Bytes::from)
+            .map_err(|err| Error::Context(err.into()))?;
+        let manifest_etag = store.put(&manifest_key, manifest_bytes).await?;
+
+        let pointer_key = namespace_scoped(ns, CURRENT_MANIFEST_KEY);
+        let pointer_bytes = serde_json::to_vec(&ManifestPointer {
+            epoch: view.epoch,
+            etag: manifest_etag,
+        })
+        .map(Bytes::from)
+        .map_err(|err| Error::Context(err.into()))?;
+        store.put(&pointer_key, pointer_bytes).await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn load_manifest_reads_pointer_and_manifest() -> Result<()> {
+        let store = InMemoryStore::default();
+        let ns = "demo";
+        let view = sample_manifest(7);
+        seed_manifest(&store, ns, &view).await?;
+
+        let loaded = load_manifest(&store, ns).await?;
+
+        assert_eq!(loaded.epoch, view.epoch);
+        assert_eq!(loaded.namespace.dim, view.namespace.dim);
+        assert_eq!(loaded.parts.len(), 1);
+        assert_eq!(loaded.delete_parts.len(), 1);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn load_manifest_detects_etag_mismatch() {
+        let store = InMemoryStore::default();
+        let ns = "demo";
+        let mut view = sample_manifest(3);
+        seed_manifest(&store, ns, &view).await.unwrap();
+
+        // Overwrite manifest with different content to desynchronise ETag values.
+        view.parts[0].part_id = PartId("p2".to_string());
+        let manifest_key = manifest_epoch_key(ns, 3);
+        let _ = store
+            .put(
+                &manifest_key,
+                Bytes::from(serde_json::to_vec(&view).unwrap()),
+            )
+            .await
+            .unwrap();
+
+        let err = load_manifest(&store, ns).await.unwrap_err();
+        assert!(format!("{err}").contains("etag mismatch"));
+    }
+
+    #[tokio::test]
+    async fn publish_manifest_writes_new_epoch_and_pointer() -> Result<()> {
+        let store = InMemoryStore::default();
+        let ns = "demo";
+        let current = sample_manifest(5);
+        seed_manifest(&store, ns, &current).await?;
+
+        let next = sample_manifest(6);
+        publish_manifest(&store, ns, &next).await?;
+
+        let loaded = load_manifest(&store, ns).await?;
+        assert_eq!(loaded.epoch, 6);
+        assert_eq!(loaded.parts[0].part_id, PartId("p1".to_string()));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn publish_manifest_rejects_stale_epoch() {
+        let store = InMemoryStore::default();
+        let ns = "demo";
+        let current = sample_manifest(4);
+        seed_manifest(&store, ns, &current).await.unwrap();
+
+        let stale = sample_manifest(4);
+        let err = publish_manifest(&store, ns, &stale).await.unwrap_err();
+        assert!(format!("{err}").contains("refusing to publish stale"));
+    }
 }

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -7,61 +7,125 @@
 //! whether data is fetched via AWS SDK, Opendal, or another adaptor.
 
 use async_trait::async_trait;
+use aws_config::BehaviorVersion;
+use aws_sdk_s3::{primitives::ByteStream, Client};
 use bytes::Bytes;
 use common::{Error, Result};
+use std::sync::Arc;
 use tracing::instrument;
 
 /// Minimal capability set required by the rest of the workspace.
 #[async_trait]
 pub trait ObjectStore: Send + Sync {
     /// Fetches the entire object located at `key`.
-    async fn get(&self, key: &str) -> Result<Bytes>;
+    async fn get(&self, key: &str) -> Result<ObjectBytes>;
 
     /// Writes a complete object, overwriting any previous value.
-    async fn put(&self, key: &str, data: Bytes) -> Result<()>;
+    async fn put(&self, key: &str, data: Bytes) -> Result<String>;
 
     /// Conditionally swaps the object if the supplied `if_match` etag is still valid.
-    async fn put_if_match(&self, key: &str, data: Bytes, if_match: &str) -> Result<()>;
+    async fn put_if_match(&self, key: &str, data: Bytes, if_match: &str) -> Result<String>;
+}
+
+/// Response payload returned from [`ObjectStore::get`].
+#[derive(Debug, Clone)]
+pub struct ObjectBytes {
+    /// Raw object contents.
+    pub data: Bytes,
+    /// Entity tag (ETag) returned by the backing store, if available.
+    pub etag: Option<String>,
+}
+
+impl ObjectBytes {
+    /// Convenience helper for constructing a response with known metadata.
+    pub fn new(data: Bytes, etag: Option<String>) -> Self {
+        Self { data, etag }
+    }
 }
 
 /// Placeholder implementation illustrating how an S3-backed store might look.
 pub struct S3Store {
     bucket: String,
+    client: Arc<Client>,
 }
 
 impl S3Store {
     /// Create a new store that targets the provided bucket.
-    pub fn new(bucket: impl Into<String>) -> Self {
+    pub fn new(client: Client, bucket: impl Into<String>) -> Self {
         Self {
             bucket: bucket.into(),
+            client: Arc::new(client),
         }
+    }
+
+    /// Constructs a store using default AWS configuration from the environment.
+    pub async fn from_env(bucket: impl Into<String>) -> Result<Self> {
+        let config = aws_config::load_defaults(BehaviorVersion::latest()).await;
+        let client = Client::new(&config);
+        Ok(Self::new(client, bucket))
     }
 }
 
 #[async_trait]
 impl ObjectStore for S3Store {
     #[instrument(skip(self))]
-    async fn get(&self, key: &str) -> Result<Bytes> {
-        Err(Error::Message(format!(
-            "not yet implemented: download {key} from {}",
-            self.bucket
-        )))
+    async fn get(&self, key: &str) -> Result<ObjectBytes> {
+        let response = self
+            .client
+            .get_object()
+            .bucket(&self.bucket)
+            .key(key)
+            .send()
+            .await
+            .map_err(|err| Error::Context(err.into()))?;
+
+        let etag = response.e_tag().map(|etag| etag.to_string());
+
+        let bytes = response
+            .body
+            .collect()
+            .await
+            .map_err(|err| Error::Context(err.into()))?
+            .into_bytes();
+
+        Ok(ObjectBytes::new(bytes, etag))
     }
 
-    #[instrument(skip(self, _data))]
-    async fn put(&self, key: &str, _data: Bytes) -> Result<()> {
-        Err(Error::Message(format!(
-            "not yet implemented: upload {key} to {}",
-            self.bucket
-        )))
+    #[instrument(skip(self, data))]
+    async fn put(&self, key: &str, data: Bytes) -> Result<String> {
+        let response = self
+            .client
+            .put_object()
+            .bucket(&self.bucket)
+            .key(key)
+            .body(ByteStream::from(data.to_vec()))
+            .send()
+            .await
+            .map_err(|err| Error::Context(err.into()))?;
+
+        response
+            .e_tag()
+            .map(|etag| etag.to_string())
+            .ok_or_else(|| Error::from("S3 did not return an ETag for put"))
     }
 
-    #[instrument(skip(self, _data))]
-    async fn put_if_match(&self, key: &str, _data: Bytes, if_match: &str) -> Result<()> {
-        Err(Error::Message(format!(
-            "not yet implemented: upload {key} to {} guarded by etag {if_match}",
-            self.bucket
-        )))
+    #[instrument(skip(self, data))]
+    async fn put_if_match(&self, key: &str, data: Bytes, if_match: &str) -> Result<String> {
+        let response = self
+            .client
+            .put_object()
+            .bucket(&self.bucket)
+            .key(key)
+            .if_match(if_match)
+            .body(ByteStream::from(data.to_vec()))
+            .send()
+            .await
+            .map_err(|err| Error::Context(err.into()))?;
+
+        response
+            .e_tag()
+            .map(|etag| etag.to_string())
+            .ok_or_else(|| Error::from("S3 did not return an ETag for conditional put"))
     }
 }
 


### PR DESCRIPTION
## Summary
- back the shared `ObjectStore` trait with an AWS SDK S3 adapter that surfaces ETags, supports conditional writes, and loads configuration from environment defaults
- implement manifest load/publish helpers with pointer validation and serialization plus an in-memory test double exercising success and failure paths
- update the project plan to mark the storage/manifest milestone complete and refresh downstream next steps

## Testing
- `cargo fmt`
- `cargo check`
- `cargo test -p manifest`


------
https://chatgpt.com/codex/tasks/task_e_68cc9c892290833297c8b5666125e9ab