### PR TITLE
Complete phase 3 systems

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,27 +35,27 @@ Update `docs/design.md` when architecture or tunables evolve. Record operational
 Legend: `TODO` = not started, `DOING` = in progress, `DONE` = complete.
 
 ### Phase 0 — Workspace Bring-Up
-- Status: TODO — Create Cargo workspace scaffolding, top-level `Cargo.toml`, and initial crate directories matching `docs/design.md` (`crates/`, `bin/`, `tests/`).
-- Status: TODO — Document build/test commands in `README.md` and ensure `cargo fmt`, `clippy`, and `test` scripts run locally.
-- Status: TODO — Add developer onboarding notes (toolchain, style) to `docs/design.md` or new `docs/runbooks/` entry.
+- Status: DONE — Create Cargo workspace scaffolding, top-level `Cargo.toml`, and initial crate directories matching `docs/design.md` (`crates/`, `bin/`, `tests/`).
+- Status: DONE — Document build/test commands in `README.md` and ensure `cargo fmt`, `clippy`, and `test` scripts run locally.
+- Status: DONE — Add developer onboarding notes (toolchain, style) to `docs/design.md` or new `docs/runbooks/` entry.
 
 ### Phase 1 — v0 Baseline (FP32 exact + ERQ-y brute fallback)
-- Status: TODO — Implement `elax-store` with WAL append, router management, and pluggable object-store clients (local + S3-compatible).
-- Status: TODO — Implement `elax-core` FP32 query path with strong consistency checks against router/WAL watermarks.
-- Status: TODO — Expose `elax-api` HTTP endpoints for `POST /v2/namespaces/:ns` writes and `POST /v2/namespaces/:ns/query` with FP32 execution.
-- Status: TODO — Provide integration tests covering strong consistency and mixed write/read batches (see Testing Guidelines).
+- Status: DONE — Implement `elax-store` with WAL append, router management, and pluggable object-store clients (local + S3-compatible).
+- Status: DONE — Implement `elax-core` FP32 query path with strong consistency checks against router/WAL watermarks.
+- Status: DONE — Expose `elax-api` HTTP endpoints for `POST /v2/namespaces/:ns` writes and `POST /v2/namespaces/:ns/query` with FP32 execution.
+- Status: DONE — Provide integration tests covering strong consistency and mixed write/read batches (see Testing Guidelines).
 
 ### Phase 2 — v0.1 IVF + ERQ Bring-Up
-- Status: DOING — Build `elax-ivf` crate for centroid training, list assignment, and nprobe selection heuristics (initial k-means++ trainer, assignment API, and nprobe heuristic landed; IVF wired into core/query planner with fallback; ERQ integration pending).
-- Status: TODO — Build `elax-erq` crate implementing Extended RaBitQ encode/decode (x-bit/y-bit) plus SIMD feature gates.
-- Status: DOING — Integrate IVF + ERQ search into `elax-core` query planner with configurable `ann_params` defaults (IVF candidate path and ANN parameter plumbing landed; ERQ wiring next).
-- Status: TODO — Implement recall evaluation endpoint (`/_debug/recall`) exercising FP32 vs ERQ paths with test fixtures.
+- Status: DONE — Build `elax-ivf` crate for centroid training, list assignment, and nprobe selection heuristics (k-means++ trainer, assignment API, and nprobe heuristic validated with core integration tests).
+- Status: DONE — Build `elax-erq` crate implementing Extended RaBitQ encode/decode (x-bit/y-bit) plus SIMD feature gates.
+- Status: DONE — Integrate IVF + ERQ search into `elax-core` query planner with configurable `ann_params` defaults, ERQ encoding, and FP32 rerank support.
+- Status: DONE — Implement recall evaluation endpoint (`/_debug/recall`) exercising FP32 vs ERQ paths with test fixtures.
 
 ### Phase 3 — v0.2 Cache, Index Maintenance, Metrics
-- Status: TODO — Implement `elax-cache` for NVMe+RAM slab management, prefetch, and eviction aligned with design.
-- Status: TODO — Extend `elax-indexer` to materialize parts, manage compaction heuristics, and publish router epochs atomically.
-- Status: TODO — Integrate `elax-metrics` (Prometheus/OpenTelemetry) into query nodes and indexers with baseline dashboards.
-- Status: TODO — Ship `elax-cli` admin tooling for compaction, verification, and export workflows.
+- Status: DONE — Implement `elax-cache` for NVMe+RAM slab management, prefetch, and eviction aligned with design.
+- Status: DONE — Extend `elax-indexer` to materialize parts, manage compaction heuristics, and publish router epochs atomically.
+- Status: DONE — Integrate `elax-metrics` (Prometheus/OpenTelemetry) into query nodes and indexers with baseline dashboards.
+- Status: DONE — Ship `elax-cli` admin tooling for compaction, verification, and export workflows.
 
 ### Phase 4 — v0.3 Feature Expansion
 - Status: TODO — Add regex index opt-in within `elax-fts` and grouped aggregation support in query planner.
@@ -77,6 +77,7 @@ Legend: `TODO` = not started, `DOING` = in progress, `DONE` = complete.
 
 - 2025-09-21 — Added `elax-ivf` k-means++ trainer with centroid assignment, probe ordering, and `nprobe` heuristic plus unit tests; remaining work tracks integration into `elax-core` planner.
 - 2025-09-22 — Wired IVF candidate search into `elax-core` with `ann_params`, automatic retraining on writes, and deterministic coverage test ensuring IVF prioritizes nearest cluster.
+- 2025-09-23 — Added ERQ quantization crate, integrated IVF+ERQ ANN planner with FP32 fallback, and exposed recall debug endpoint with coverage tests.
 
 ### Outstanding Issues
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,10 +119,10 @@ dependencies = [
  "axum-macros",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.7.0",
  "hyper-util",
  "itoa",
  "matchit",
@@ -152,8 +152,8 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -191,16 +191,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
 name = "bitflags"
 version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 
 [[package]]
+name = "bumpalo"
+version = "3.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
 name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+
+[[package]]
+name = "cc"
+version = "1.2.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80f41ae168f955c12fb8960b057d70d0ca153fb83182b57d86380443527be7e9"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -255,14 +277,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "elax-api"
 version = "0.0.0"
 dependencies = [
  "anyhow",
  "axum",
  "elax-core",
+ "elax-metrics",
  "elax-store",
  "http-body-util",
+ "metrics 0.21.1",
  "serde",
  "serde_json",
  "tokio",
@@ -274,7 +329,9 @@ name = "elax-cache"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "metrics 0.21.1",
  "parking_lot",
+ "tempfile",
 ]
 
 [[package]]
@@ -283,6 +340,10 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "clap",
+ "elax-indexer",
+ "elax-store",
+ "serde_json",
+ "tokio",
 ]
 
 [[package]]
@@ -290,8 +351,11 @@ name = "elax-core"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "elax-erq",
  "elax-ivf",
+ "elax-metrics",
  "elax-store",
+ "metrics 0.21.1",
  "serde",
  "serde_json",
  "tokio",
@@ -325,6 +389,9 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "elax-store",
+ "metrics 0.21.1",
+ "tempfile",
+ "tokio",
 ]
 
 [[package]]
@@ -340,7 +407,9 @@ name = "elax-metrics"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "metrics",
+ "metrics 0.21.1",
+ "metrics-exporter-prometheus",
+ "once_cell",
 ]
 
 [[package]]
@@ -355,10 +424,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ced73b1dacfc750a6db6c0a0c3a3853c8b41997e2e2c563dc90804ae6867959"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -410,7 +522,19 @@ checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.7+wasi-0.2.4",
 ]
 
 [[package]]
@@ -420,10 +544,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
 
 [[package]]
 name = "http"
@@ -438,12 +594,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.3.1",
 ]
 
 [[package]]
@@ -454,8 +621,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -473,6 +640,29 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e"
@@ -481,8 +671,8 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "http",
- "http-body",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "httparse",
  "httpdate",
  "itoa",
@@ -493,6 +683,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper 0.14.32",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -500,12 +703,22 @@ checksum = "3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
- "hyper",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "hyper 1.7.0",
  "pin-project-lite",
  "tokio",
  "tower-service",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.16.0",
 ]
 
 [[package]]
@@ -520,6 +733,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -532,10 +751,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "js-sys"
+version = "0.3.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "852f13bec5eba4ba9afbeb93fd7c13fe56147f055939ae21c43a29a0ecb2702e"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "lock_api"
@@ -577,6 +812,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "metrics"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56d05972e8cbac2671e85aa9d04d9160d193f8bebd1a5c1a2f4542c62e65d1d0"
+dependencies = [
+ "ahash",
+ "portable-atomic",
+]
+
+[[package]]
+name = "metrics-exporter-prometheus"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bf4e7146e30ad172c42c39b3246864bd2d3c6396780711a1baf749cfe423e21"
+dependencies = [
+ "base64",
+ "hyper 0.14.32",
+ "hyper-tls",
+ "indexmap",
+ "ipnet",
+ "metrics 0.22.4",
+ "metrics-util",
+ "quanta",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "metrics-macros"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -585,6 +849,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b07a5eb561b8cbc16be2d216faf7757f9baf3bfb94dbb0fae3df8387a5bb47f"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "metrics 0.22.4",
+ "num_cpus",
+ "quanta",
+ "sketches-ddsketch",
 ]
 
 [[package]]
@@ -609,8 +888,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -633,6 +939,50 @@ name = "once_cell_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
+name = "openssl"
+version = "0.10.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "parking_lot"
@@ -696,6 +1046,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
 name = "portable-atomic"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -720,6 +1076,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "query-node"
 version = "0.0.0"
 dependencies = [
@@ -737,6 +1108,12 @@ checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
@@ -765,7 +1142,16 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.16",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -784,6 +1170,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
+name = "rustix"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -796,10 +1195,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "schannel"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+dependencies = [
+ "windows-sys 0.61.0",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "serde"
@@ -868,6 +1299,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "sketches-ddsketch"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85636c14b73d81f541e525f585c0a2109e6744e1565b5c1668e31c70c10ed65c"
+
+[[package]]
 name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -878,6 +1321,16 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "socket2"
@@ -913,6 +1366,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
+name = "tempfile"
+version = "3.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84fa4d11fadde498443cca10fd3ac23c951f0dc59e080e9f4b93d4df4e4eea53"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tokio"
 version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -925,7 +1411,7 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "slab",
- "socket2",
+ "socket2 0.6.0",
  "tokio-macros",
  "windows-sys 0.59.0",
 ]
@@ -939,6 +1425,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -992,7 +1488,19 @@ checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1003,6 +1511,12 @@ checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
 ]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "unicode-ident"
@@ -1017,10 +1531,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
 
 [[package]]
 name = "wasi"
@@ -1029,10 +1558,133 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasi"
+version = "0.14.7+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab10a69fbd0a177f5f649ad4d8d3305499c42bab9aef2f7ff592d0ec8f833819"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bb702423545a6007bbc368fde243ba47ca275e549c8a28617f56f6ba53b1d1c"
+dependencies = [
+ "bumpalo",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc65f4f411d91494355917b605e1480033152658d71f722a90647f56a70c88a0"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffc003a991398a8ee604a401e194b6b3a39677b3173d6e74495eb51b82e99a32"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "293c37f4efa430ca14db3721dfbe48d8c33308096bd44d80ebaa775ab71ba1cf"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbe734895e869dc429d78c4b433f8d17d95f8d05317440b4fad5ab2d33e596dc"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
 name = "windows-link"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-link"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "windows-sys"
@@ -1050,6 +1702,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
  "windows-targets 0.53.3",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e201184e40b2ede64bc2ea34968b28e33622acdbbf37104f0e4a33f7abe657aa"
+dependencies = [
+ "windows-link 0.2.0",
 ]
 
 [[package]]
@@ -1074,7 +1735,7 @@ version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",
@@ -1180,6 +1841,12 @@ name = "windows_x86_64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "zerocopy"

--- a/crates/elax-api/Cargo.toml
+++ b/crates/elax-api/Cargo.toml
@@ -14,6 +14,8 @@ serde_json = "1"
 axum = { version = "0.7", features = ["macros"] }
 elax-core = { path = "../elax-core" }
 elax-store = { path = "../elax-store" }
+elax-metrics = { path = "../elax-metrics" }
+metrics = "0.21"
 
 [dev-dependencies]
 tower = { version = "0.4", features = ["util"] }

--- a/crates/elax-api/tests/phase1_flow.rs
+++ b/crates/elax-api/tests/phase1_flow.rs
@@ -93,3 +93,186 @@ async fn write_and_query_round_trip() {
     assert_eq!(hits.len(), 1);
     assert_eq!(hits[0]["id"], "doc-1");
 }
+
+#[tokio::test]
+async fn write_rejects_empty_document_id() {
+    let store = temp_store();
+    let server = ApiServer::new(store);
+    let app = server.router();
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v2/namespaces/test")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({ "upserts": [{ "id": "", "vector": [1.0] }] }).to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    let message = value["error"].as_str().unwrap();
+    assert!(message.contains("id must not be empty"));
+}
+
+#[tokio::test]
+async fn query_errors_when_consistency_unmet() {
+    let store = temp_store();
+    let server = ApiServer::new(store);
+    let app = server.router();
+
+    let write_body = json!({
+        "upserts": [
+            { "id": "doc-1", "vector": [1.0, 0.0] }
+        ]
+    });
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v2/namespaces/test")
+                .header("content-type", "application/json")
+                .body(Body::from(write_body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let wal_sequence = serde_json::from_slice::<serde_json::Value>(&bytes).unwrap()["wal_sequence"]
+        .as_u64()
+        .unwrap();
+
+    let query_body = json!({
+        "vector": [1.0, 0.0],
+        "top_k": 1,
+        "min_wal_sequence": wal_sequence + 5
+    });
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v2/namespaces/test/query")
+                .header("content-type", "application/json")
+                .body(Body::from(query_body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let error: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert!(error["error"]
+        .as_str()
+        .unwrap()
+        .contains("consistency level unmet"));
+}
+
+#[tokio::test]
+async fn recall_endpoint_reports_full_recall_with_fp32_rerank() {
+    let store = temp_store();
+    let server = ApiServer::new(store);
+    let app = server.router();
+
+    let docs: Vec<_> = (0..12)
+        .map(|i| {
+            json!({
+                "id": format!("doc-{i}"),
+                "vector": [i as f32, (i % 3) as f32],
+            })
+        })
+        .collect();
+    let write_body = json!({ "upserts": docs });
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v2/namespaces/test")
+                .header("content-type", "application/json")
+                .body(Body::from(write_body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let recall_body = json!({
+        "num": 5,
+        "top_k": 3,
+        "ann_params": { "rerank_mode": "fp32", "target_recall": 1.0 }
+    });
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/namespaces/test/_debug/recall")
+                .header("content-type", "application/json")
+                .body(Body::from(recall_body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(value["evaluated"].as_u64().unwrap(), 5);
+    let avg_recall = value["avg_recall"].as_f64().unwrap();
+    assert!((avg_recall - 1.0).abs() < 1e-6, "recall should be 1.0");
+}
+
+#[tokio::test]
+async fn metrics_endpoint_returns_prometheus_payload() {
+    let store = temp_store();
+    let server = ApiServer::new(store);
+    let app = server.router();
+
+    let write_body = json!({
+        "upserts": [
+            { "id": "doc-1", "vector": [0.0, 1.0] }
+        ]
+    });
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v2/namespaces/test")
+                .header("content-type", "application/json")
+                .body(Body::from(write_body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/metrics")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let text = String::from_utf8_lossy(&body);
+    assert!(text.contains("elax_metrics_up"));
+}

--- a/crates/elax-cache/Cargo.toml
+++ b/crates/elax-cache/Cargo.toml
@@ -9,3 +9,7 @@ rust-version.workspace = true
 [dependencies]
 anyhow = "1"
 parking_lot = "0.12"
+metrics = "0.21"
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/elax-cache/src/lib.rs
+++ b/crates/elax-cache/src/lib.rs
@@ -1,30 +1,469 @@
-//! NVMe and RAM cache manager scaffolding.
+//! NVMe and RAM cache manager aligned with the Phase 3 design goals.
 
-use anyhow::Result;
-use parking_lot::Mutex;
+use std::{
+    collections::{HashMap, HashSet},
+    fmt, fs,
+    hash::{Hash, Hasher},
+    path::PathBuf,
+    sync::Arc,
+    time::Instant,
+};
 
-/// Placeholder cache container storing a byte counter.
-pub struct Cache {
-    bytes: Mutex<usize>,
+use anyhow::{Context, Result};
+use metrics::{counter, gauge};
+use parking_lot::{Mutex, MutexGuard};
+
+/// Configuration for the cache hierarchy.
+#[derive(Debug, Clone)]
+pub struct CacheConfig {
+    pub nvme_root: PathBuf,
+    pub ram_bytes: usize,
+    pub slab_bytes: usize,
 }
 
-impl Cache {
-    pub fn new() -> Self {
+impl CacheConfig {
+    pub fn new(root: impl Into<PathBuf>, ram_bytes: usize, slab_bytes: usize) -> Self {
         Self {
-            bytes: Mutex::new(0),
+            nvme_root: root.into(),
+            ram_bytes,
+            slab_bytes: slab_bytes.max(4096),
+        }
+    }
+}
+
+impl Default for CacheConfig {
+    fn default() -> Self {
+        Self {
+            nvme_root: PathBuf::from(".elacsym/cache"),
+            ram_bytes: 256 * 1024 * 1024,
+            slab_bytes: 2 * 1024 * 1024,
+        }
+    }
+}
+
+/// Identifies a cached asset.
+#[derive(Clone, Eq)]
+pub struct CacheKey {
+    namespace: String,
+    asset: String,
+    kind: AssetKind,
+}
+
+impl CacheKey {
+    pub fn new(namespace: impl Into<String>, asset: impl Into<String>, kind: AssetKind) -> Self {
+        Self {
+            namespace: namespace.into(),
+            asset: asset.into(),
+            kind,
         }
     }
 
-    /// Pretend to reserve space in the cache.
-    pub fn reserve(&self, amount: usize) -> Result<()> {
-        let mut guard = self.bytes.lock();
-        *guard += amount;
-        Ok(())
+    fn namespace(&self) -> &str {
+        &self.namespace
+    }
+
+    fn filename(&self) -> String {
+        let mut sanitized = self.asset.replace('/', "_");
+        if sanitized.is_empty() {
+            sanitized = "root".to_string();
+        }
+        format!("{}-{}.bin", self.kind.as_str(), sanitized)
     }
 }
 
-impl Default for Cache {
-    fn default() -> Self {
-        Self::new()
+impl PartialEq for CacheKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.namespace == other.namespace && self.asset == other.asset && self.kind == other.kind
+    }
+}
+
+impl Hash for CacheKey {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.namespace.hash(state);
+        self.asset.hash(state);
+        self.kind.hash(state);
+    }
+}
+
+/// Categories of cached assets.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+pub enum AssetKind {
+    Centroids,
+    Postings,
+    RerankCodes,
+    Filters,
+    Blob,
+}
+
+impl AssetKind {
+    fn as_str(&self) -> &'static str {
+        match self {
+            AssetKind::Centroids => "centroids",
+            AssetKind::Postings => "postings",
+            AssetKind::RerankCodes => "rerank",
+            AssetKind::Filters => "filters",
+            AssetKind::Blob => "blob",
+        }
+    }
+}
+
+impl fmt::Display for AssetKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+#[derive(Clone)]
+struct CacheEntry {
+    path: PathBuf,
+    allocated: usize,
+    resident: Option<Arc<Vec<u8>>>,
+    last_access: Instant,
+    namespace: String,
+    kind: AssetKind,
+}
+
+impl CacheEntry {
+    fn new(path: PathBuf, allocated: usize, namespace: String, kind: AssetKind) -> Self {
+        Self {
+            path,
+            allocated,
+            resident: None,
+            last_access: Instant::now(),
+            namespace,
+            kind,
+        }
+    }
+}
+
+struct CacheState {
+    entries: HashMap<CacheKey, CacheEntry>,
+    ram_used: usize,
+    pinned_namespaces: HashSet<String>,
+}
+
+impl CacheState {
+    fn new() -> Self {
+        Self {
+            entries: HashMap::new(),
+            ram_used: 0,
+            pinned_namespaces: HashSet::new(),
+        }
+    }
+}
+
+/// Runtime statistics for the cache. Intended for testing and introspection.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct CacheStats {
+    pub entry_count: usize,
+    pub ram_bytes: usize,
+}
+
+/// Two-tier cache storing IVF/ERQ assets on NVMe and optionally keeping them in
+/// RAM slabs for hot reuse.
+pub struct Cache {
+    config: CacheConfig,
+    state: Mutex<CacheState>,
+}
+
+impl Cache {
+    pub fn new(config: CacheConfig) -> Result<Self> {
+        if !config.nvme_root.exists() {
+            fs::create_dir_all(&config.nvme_root)
+                .with_context(|| format!("creating cache root: {:?}", config.nvme_root))?;
+        }
+        Ok(Self {
+            config,
+            state: Mutex::new(CacheState::new()),
+        })
+    }
+
+    pub fn pin_namespace(&self, namespace: impl Into<String>, pin: bool) {
+        let namespace = namespace.into();
+        let mut guard = self.state.lock();
+        if pin {
+            guard.pinned_namespaces.insert(namespace.clone());
+        } else {
+            guard.pinned_namespaces.remove(&namespace);
+        }
+        gauge!("elax_cache_ram_bytes", guard.ram_used as f64, "namespace" => namespace);
+    }
+
+    /// Insert or overwrite an asset in the cache.
+    pub fn insert(&self, key: CacheKey, bytes: Arc<Vec<u8>>) -> Result<()> {
+        let path = self.asset_path(&key);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("creating cache namespace dir: {:?}", parent))?;
+        }
+        fs::write(&path, bytes.as_slice())
+            .with_context(|| format!("persisting cache asset: {:?}", path))?;
+
+        let allocated = self.align(bytes.len());
+        let mut guard = self.state.lock();
+        let mut entry = CacheEntry::new(path, allocated, key.namespace().to_string(), key.kind);
+        entry.resident = Some(bytes);
+        self.attach_entry(&mut guard, key, entry);
+        Ok(())
+    }
+
+    /// Read an asset into memory, returning a clone of the stored bytes.
+    pub fn get(&self, key: &CacheKey) -> Result<Option<Arc<Vec<u8>>>> {
+        let lookup = {
+            let mut guard = self.state.lock();
+            if let Some(entry) = guard.entries.get_mut(key) {
+                entry.last_access = Instant::now();
+                let namespace = entry.namespace.clone();
+                let kind = entry.kind;
+                if let Some(bytes) = &entry.resident {
+                    counter!(
+                        "elax_cache_hits_total",
+                        1,
+                        "namespace" => namespace.clone(),
+                        "kind" => entry.kind.as_str()
+                    );
+                    return Ok(Some(bytes.clone()));
+                }
+                counter!(
+                    "elax_cache_misses_total",
+                    1,
+                    "namespace" => namespace.clone(),
+                    "kind" => entry.kind.as_str()
+                );
+                Some((entry.path.clone(), namespace, kind))
+            } else {
+                None
+            }
+        };
+
+        let (path, namespace, kind) = match lookup {
+            Some(data) => data,
+            None => return Ok(None),
+        };
+
+        let bytes = fs::read(&path)
+            .with_context(|| format!("reading cached asset from disk: {:?}", path))?;
+        let arc = Arc::new(bytes);
+
+        let mut guard = self.state.lock();
+        if let Some(entry) = guard.entries.get_mut(key) {
+            entry.last_access = Instant::now();
+            if entry.resident.is_none() {
+                entry.resident = Some(arc.clone());
+                guard.ram_used += entry.allocated;
+                self.evict_if_needed(&mut guard);
+            }
+            gauge!(
+                "elax_cache_ram_bytes",
+                guard.ram_used as f64,
+                "namespace" => namespace.clone()
+            );
+        }
+        counter!(
+            "elax_cache_hits_total",
+            1,
+            "namespace" => namespace,
+            "kind" => kind.as_str()
+        );
+        Ok(Some(arc))
+    }
+
+    /// Ensure that the asset is loaded into memory, returning whether it was
+    /// newly prefetched.
+    pub fn prefetch(&self, key: &CacheKey) -> Result<bool> {
+        let should_load = {
+            let guard = self.state.lock();
+            guard
+                .entries
+                .get(key)
+                .map(|entry| entry.resident.is_none())
+                .unwrap_or(false)
+        };
+        if !should_load {
+            return Ok(false);
+        }
+        let bytes = match self.get(key)? {
+            Some(bytes) => bytes,
+            None => return Ok(false),
+        };
+        Ok(!bytes.is_empty())
+    }
+
+    pub fn stats(&self) -> CacheStats {
+        let guard = self.state.lock();
+        CacheStats {
+            entry_count: guard.entries.len(),
+            ram_bytes: guard.ram_used,
+        }
+    }
+
+    fn align(&self, size: usize) -> usize {
+        let slab = self.config.slab_bytes;
+        size.div_ceil(slab) * slab
+    }
+
+    fn asset_path(&self, key: &CacheKey) -> PathBuf {
+        self.config
+            .nvme_root
+            .join("namespaces")
+            .join(&key.namespace)
+            .join(key.filename())
+    }
+
+    fn attach_entry(
+        &self,
+        guard: &mut MutexGuard<'_, CacheState>,
+        key: CacheKey,
+        entry: CacheEntry,
+    ) {
+        if let Some(prev) = guard.entries.insert(key.clone(), entry.clone()) {
+            if let Some(bytes) = prev.resident {
+                guard.ram_used = guard.ram_used.saturating_sub(prev.allocated);
+                drop(bytes);
+            }
+        }
+        if entry.resident.is_some() {
+            guard.ram_used += entry.allocated;
+            gauge!("elax_cache_ram_bytes", guard.ram_used as f64, "namespace" => entry.namespace.clone());
+            self.evict_if_needed(guard);
+        }
+    }
+
+    fn evict_if_needed(&self, guard: &mut CacheState) {
+        while guard.ram_used > self.config.ram_bytes {
+            if let Some((key, entry)) = self.select_victim(guard) {
+                if let Some(bytes) = entry.resident {
+                    drop(bytes);
+                }
+                guard.ram_used = guard.ram_used.saturating_sub(entry.allocated);
+                let namespace = entry.namespace.clone();
+                let kind = entry.kind;
+                guard.entries.insert(
+                    key,
+                    CacheEntry {
+                        resident: None,
+                        ..entry
+                    },
+                );
+                counter!(
+                    "elax_cache_evictions_total",
+                    1,
+                    "namespace" => namespace,
+                    "kind" => kind.as_str()
+                );
+            } else {
+                break;
+            }
+        }
+    }
+
+    fn select_victim(&self, guard: &mut CacheState) -> Option<(CacheKey, CacheEntry)> {
+        guard
+            .entries
+            .iter()
+            .filter(|(key, entry)| {
+                entry.resident.is_some() && !guard.pinned_namespaces.contains(key.namespace())
+            })
+            .min_by_key(|(_, entry)| entry.last_access)
+            .map(|(key, entry)| (key.clone(), entry.clone()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn cache_config() -> (TempDir, CacheConfig) {
+        let temp = TempDir::new().expect("create temp dir");
+        let config = CacheConfig::new(temp.path(), 8 * 1024, 4096);
+        (temp, config)
+    }
+
+    fn sample_key(ns: &str, idx: usize) -> CacheKey {
+        CacheKey::new(ns.to_string(), format!("asset-{idx}"), AssetKind::Blob)
+    }
+
+    #[test]
+    fn insert_and_get_round_trip() {
+        let (_temp, config) = cache_config();
+        let cache = Cache::new(config).unwrap();
+        let key = sample_key("ns", 1);
+        cache
+            .insert(key.clone(), Arc::new(vec![1, 2, 3, 4]))
+            .expect("insert");
+        let value = cache.get(&key).unwrap().expect("fetch");
+        assert_eq!(&*value, &[1, 2, 3, 4]);
+        assert_eq!(cache.stats().entry_count, 1);
+    }
+
+    #[test]
+    fn evicts_least_recently_used_when_ram_exceeded() {
+        let (_temp, config) = cache_config();
+        let cache = Cache::new(config).unwrap();
+        for idx in 0..3 {
+            let key = sample_key("ns", idx);
+            cache
+                .insert(key, Arc::new(vec![0u8; 4096]))
+                .expect("insert");
+        }
+        // Insert large blob to force eviction of earliest key.
+        let hot_key = sample_key("ns", 99);
+        cache
+            .insert(hot_key.clone(), Arc::new(vec![0u8; 4096]))
+            .expect("insert hot");
+        // Trigger read of other entries to populate.
+        let second_key = sample_key("ns", 1);
+        cache.get(&second_key).unwrap();
+        cache.get(&hot_key).unwrap();
+        let first_key = sample_key("ns", 0);
+        {
+            let guard = cache.state.lock();
+            let entry = guard.entries.get(&first_key).unwrap();
+            assert!(entry.resident.is_none(), "entry should be evicted from RAM");
+        }
+        let bytes = cache.get(&first_key).unwrap().unwrap();
+        assert_eq!(bytes.len(), 4096);
+    }
+
+    #[test]
+    fn pinned_namespaces_are_not_evicted() {
+        let (_temp, config) = cache_config();
+        let cache = Cache::new(config).unwrap();
+        let key = sample_key("vip", 0);
+        cache.pin_namespace("vip", true);
+        cache
+            .insert(key.clone(), Arc::new(vec![0u8; 4096]))
+            .expect("insert");
+        // Fill cache to force eviction but pinned namespace should remain.
+        for idx in 0..4 {
+            cache
+                .insert(sample_key("ns", idx), Arc::new(vec![0u8; 4096]))
+                .expect("insert other");
+        }
+        let value = cache.get(&key).unwrap();
+        assert!(value.is_some());
+    }
+
+    #[test]
+    fn prefetch_promotes_to_memory() {
+        let (_temp, config) = cache_config();
+        let cache = Cache::new(config).unwrap();
+        let key = sample_key("ns", 42);
+        cache
+            .insert(key.clone(), Arc::new(vec![9u8; 1024]))
+            .expect("insert");
+        {
+            let mut guard = cache.state.lock();
+            if let Some(entry) = guard.entries.get_mut(&key) {
+                let allocated = entry.allocated;
+                entry.resident = None;
+                guard.ram_used = guard.ram_used.saturating_sub(allocated);
+            }
+        }
+        let loaded = cache.prefetch(&key).unwrap();
+        assert!(loaded);
+        let value = cache.get(&key).unwrap().unwrap();
+        assert_eq!(value.len(), 1024);
     }
 }

--- a/crates/elax-cli/Cargo.toml
+++ b/crates/elax-cli/Cargo.toml
@@ -9,3 +9,7 @@ rust-version.workspace = true
 [dependencies]
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
+elax-indexer = { path = "../elax-indexer" }
+elax-store = { path = "../elax-store" }
+serde_json = "1"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/crates/elax-cli/src/main.rs
+++ b/crates/elax-cli/src/main.rs
@@ -1,14 +1,103 @@
 //! Command-line tooling for elacsym administration.
 
-use anyhow::Result;
-use clap::Parser;
+use std::collections::HashSet;
+
+use anyhow::{anyhow, Result};
+use clap::{Parser, Subcommand};
+use elax_indexer::{Indexer, IndexerConfig};
+use elax_store::{LocalStore, WalBatch};
+use serde_json::json;
 
 #[derive(Parser, Debug)]
-#[command(author, version, about)]
-struct Cli {}
+#[command(author, version, about = "Administrative tooling for elacsym clusters")]
+struct Cli {
+    /// Path to the workspace data root.
+    #[arg(long, default_value = ".elacsym")]
+    root: String,
 
-fn main() -> Result<()> {
-    let _ = Cli::parse();
-    println!("elax-cli placeholder");
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand, Debug)]
+enum Command {
+    /// Materialize pending WAL entries and run compaction if needed.
+    Compact {
+        /// Namespace to index.
+        namespace: String,
+    },
+    /// Verify router state and part manifests for a namespace.
+    Verify { namespace: String },
+    /// Export WAL batches since an optional sequence number to stdout as JSON.
+    ExportWal {
+        namespace: String,
+        #[arg(long, default_value_t = 0)]
+        since: u64,
+    },
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let cli = Cli::parse();
+    let store = LocalStore::new(&cli.root);
+
+    match cli.command {
+        Command::Compact { namespace } => {
+            let indexer = Indexer::new(store.clone(), IndexerConfig::default());
+            let router = indexer.run_until_idle(&namespace).await?;
+            println!(
+                "compacted namespace '{}' to {} parts (indexed_wal={})",
+                namespace,
+                router.parts.len(),
+                router.indexed_wal
+            );
+        }
+        Command::Verify { namespace } => verify_namespace(&store, &namespace).await?,
+        Command::ExportWal { namespace, since } => export_wal(&store, &namespace, since).await?,
+    }
+
+    Ok(())
+}
+
+async fn verify_namespace(store: &LocalStore, namespace: &str) -> Result<()> {
+    let ns_store = store.namespace(namespace.to_string());
+    let router = ns_store.load_router().await?;
+    let manifests = ns_store.list_part_manifests().await?;
+
+    let router_ids: HashSet<_> = router.parts.iter().map(|p| p.id.clone()).collect();
+    let manifest_ids: HashSet<_> = manifests.iter().map(|p| p.id.clone()).collect();
+
+    if !router_ids.is_subset(&manifest_ids) {
+        return Err(anyhow!(
+            "router references missing manifests: {:?}",
+            router_ids.difference(&manifest_ids).collect::<Vec<_>>()
+        ));
+    }
+
+    println!(
+        "namespace '{}' verified: {} parts, wal_highwater={}, indexed_wal={}",
+        namespace,
+        router.parts.len(),
+        router.wal_highwater,
+        router.indexed_wal
+    );
+    Ok(())
+}
+
+async fn export_wal(store: &LocalStore, namespace: &str, since: u64) -> Result<()> {
+    let ns_store = store.namespace(namespace.to_string());
+    let batches = ns_store.load_batches_since(since).await?;
+    for (pointer, batch) in batches {
+        print_batch(&pointer.sequence, &batch)?;
+    }
+    Ok(())
+}
+
+fn print_batch(sequence: &u64, batch: &WalBatch) -> Result<()> {
+    let payload = json!({
+        "sequence": sequence,
+        "operations": batch.operations,
+    });
+    println!("{}", serde_json::to_string_pretty(&payload)?);
     Ok(())
 }

--- a/crates/elax-core/Cargo.toml
+++ b/crates/elax-core/Cargo.toml
@@ -10,6 +10,9 @@ rust-version.workspace = true
 anyhow = "1"
 elax-store = { path = "../elax-store" }
 elax-ivf = { path = "../elax-ivf" }
+elax-erq = { path = "../elax-erq" }
+elax-metrics = { path = "../elax-metrics" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["sync", "macros"] }
+metrics = "0.21"

--- a/crates/elax-core/src/lib.rs
+++ b/crates/elax-core/src/lib.rs
@@ -4,11 +4,17 @@ use std::{
     cmp::Ordering,
     collections::{HashMap, HashSet},
     sync::Arc,
+    time::Instant,
 };
 
 use anyhow::{anyhow, Context, Result};
+use elax_erq::{
+    self as erq, DistanceMetric as ErqDistanceMetric, EncodedVector as ErqEncodedVector,
+    Model as ErqModel, TrainConfig as ErqTrainConfig,
+};
 use elax_ivf::{self as ivf, IvfModel, TrainParams};
 use elax_store::{Document, LocalStore, NamespaceStore, WalBatch, WalPointer, WriteOp};
+use metrics::{counter, gauge, histogram};
 use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
 
@@ -17,6 +23,8 @@ const IVF_MAX_LISTS: usize = 256;
 const IVF_TRAIN_SEED: u64 = 20_240_921;
 const IVF_MAX_ITERATIONS: usize = 50;
 const IVF_TOLERANCE: f32 = 1e-4;
+const ERQ_DEFAULT_COARSE_BITS: u8 = 1;
+const ERQ_DEFAULT_RERANK_BITS: u8 = 8;
 
 /// Registry that coordinates namespace lifecycles backed by the storage layer.
 #[derive(Clone)]
@@ -27,6 +35,7 @@ pub struct NamespaceRegistry {
 
 impl NamespaceRegistry {
     pub fn new(store: LocalStore) -> Self {
+        let _ = elax_metrics::init();
         Self {
             store,
             namespaces: Arc::new(RwLock::new(HashMap::new())),
@@ -54,13 +63,44 @@ impl NamespaceRegistry {
     pub async fn apply_write(&self, batch: WriteBatch) -> Result<WalPointer> {
         let namespace = batch.namespace.clone();
         let ns = self.namespace_state(&namespace).await?;
-        ns.apply_write(&batch).await
+        let start = Instant::now();
+        let pointer = ns.apply_write(&batch).await?;
+        counter!(
+            "elax_core_write_requests_total",
+            1,
+            "namespace" => namespace.clone()
+        );
+        histogram!(
+            "elax_core_write_latency_seconds",
+            start.elapsed().as_secs_f64(),
+            "namespace" => namespace
+        );
+        Ok(pointer)
     }
 
     /// Execute a FP32 query with strong consistency semantics.
     pub async fn query(&self, request: QueryRequest) -> Result<QueryResponse> {
+        let namespace = request.namespace.clone();
+        let ns = self.namespace_state(&namespace).await?;
+        let start = Instant::now();
+        let response = ns.query(request).await?;
+        counter!(
+            "elax_core_query_requests_total",
+            1,
+            "namespace" => namespace.clone()
+        );
+        histogram!(
+            "elax_core_query_latency_seconds",
+            start.elapsed().as_secs_f64(),
+            "namespace" => namespace
+        );
+        Ok(response)
+    }
+
+    /// Evaluate ANN recall against exhaustive search for the namespace.
+    pub async fn debug_recall(&self, request: RecallRequest) -> Result<RecallResponse> {
         let ns = self.namespace_state(&request.namespace).await?;
-        ns.query(request).await
+        ns.debug_recall(request).await
     }
 }
 
@@ -97,6 +137,11 @@ impl NamespaceState {
         let mut guard = self.inner.write().await;
         guard.apply_batch(&wal_batch)?;
         guard.wal_highwater = pointer.sequence;
+        gauge!(
+            "elax_core_rows_cached",
+            guard.rows.len() as f64,
+            "namespace" => batch.namespace.clone()
+        );
         Ok(pointer)
     }
 
@@ -127,6 +172,11 @@ impl NamespaceState {
 
         let results = guard.search(&request)?;
         Ok(QueryResponse { hits: results })
+    }
+
+    async fn debug_recall(&self, request: RecallRequest) -> Result<RecallResponse> {
+        let mut guard = self.inner.write().await;
+        guard.debug_recall(&request)
     }
 }
 
@@ -175,27 +225,16 @@ impl NamespaceInner {
             return Err(anyhow!("query vector must not be empty"));
         }
 
-        if self.ivf_dirty && request.ann_params.use_ivf {
-            self.rebuild_ivf(metric)?;
+        let mut ann_params = request.ann_params.clone();
+        ann_params.fill_defaults();
+
+        if ann_params.use_ivf {
+            self.ensure_ivf(metric, &ann_params)?;
         }
 
-        let mut results = if request.ann_params.use_ivf {
-            if let Some(index) = self.ivf.as_ref() {
-                index.search(
-                    query_vec,
-                    metric,
-                    request.top_k,
-                    &request.ann_params,
-                    &self.rows,
-                )?
-            } else {
-                Vec::new()
-            }
-        } else {
-            Vec::new()
-        };
-
+        let mut results = self.ann_hits(query_vec, metric, request.top_k, &ann_params)?;
         if results.len() >= request.top_k {
+            results.sort_by(compare_hits);
             results.truncate(request.top_k);
             return Ok(results);
         }
@@ -209,13 +248,113 @@ impl NamespaceInner {
         for hit in brute {
             if seen.insert(hit.id.clone()) {
                 results.push(hit);
-                if results.len() >= request.top_k {
-                    break;
-                }
             }
         }
+        results.sort_by(compare_hits);
         results.truncate(request.top_k);
         Ok(results)
+    }
+
+    fn ensure_ivf(&mut self, metric: DistanceMetric, ann: &AnnParams) -> Result<()> {
+        let coarse_bits = ann.coarse_bits.unwrap_or(ERQ_DEFAULT_COARSE_BITS);
+        let rerank_bits = ann.rerank_bits.unwrap_or(ERQ_DEFAULT_RERANK_BITS);
+        let needs_rebuild = self.ivf_dirty
+            || self
+                .ivf
+                .as_ref()
+                .map(|index| !index.matches(metric, coarse_bits, rerank_bits))
+                .unwrap_or(true);
+        if needs_rebuild {
+            self.rebuild_ivf(metric, coarse_bits, rerank_bits)?;
+        }
+        Ok(())
+    }
+
+    fn ann_hits(
+        &mut self,
+        query_vec: &[f32],
+        metric: DistanceMetric,
+        top_k: usize,
+        ann: &AnnParams,
+    ) -> Result<Vec<QueryHit>> {
+        if !ann.use_ivf || top_k == 0 {
+            return Ok(Vec::new());
+        }
+        if let Some(index) = self.ivf.as_ref() {
+            index.search(query_vec, metric, top_k, ann, &self.rows)
+        } else {
+            Ok(Vec::new())
+        }
+    }
+
+    fn debug_recall(&mut self, request: &RecallRequest) -> Result<RecallResponse> {
+        let metric = request.metric.unwrap_or(self.config.distance_metric);
+        let mut ann_params = request.ann_params.clone();
+        ann_params.fill_defaults();
+
+        if ann_params.use_ivf {
+            self.ensure_ivf(metric, &ann_params)?;
+        }
+
+        let target = request.num.max(1);
+        let mut queries: Vec<Vec<f32>> = if let Some(explicit) = request.queries.clone() {
+            explicit.into_iter().take(target).collect()
+        } else {
+            self.rows
+                .values()
+                .filter_map(|row| row.vector.clone())
+                .take(target)
+                .collect()
+        };
+
+        if queries.is_empty() {
+            return Ok(RecallResponse::empty());
+        }
+
+        let top_k = request.top_k.max(1);
+        let mut evaluated = 0usize;
+        let mut total_recall = 0.0f32;
+        let mut total_ann = 0usize;
+        let mut total_brute = 0usize;
+
+        for query in queries.drain(..) {
+            if query.is_empty() {
+                continue;
+            }
+            let ann_hits = match self.ann_hits(&query, metric, top_k, &ann_params) {
+                Ok(hits) => hits,
+                Err(_) => continue,
+            };
+            let brute_hits = match self.brute_force_search(&query, metric, top_k) {
+                Ok(hits) => hits,
+                Err(_) => continue,
+            };
+            if brute_hits.is_empty() {
+                continue;
+            }
+
+            let brute_ids: HashSet<&str> = brute_hits.iter().map(|hit| hit.id.as_str()).collect();
+            let matches = ann_hits
+                .iter()
+                .filter(|hit| brute_ids.contains(hit.id.as_str()))
+                .count();
+            let denom = brute_hits.len().min(top_k).max(1);
+            total_recall += matches as f32 / denom as f32;
+            total_ann += ann_hits.len();
+            total_brute += brute_hits.len();
+            evaluated += 1;
+        }
+
+        if evaluated == 0 {
+            return Ok(RecallResponse::empty());
+        }
+
+        Ok(RecallResponse {
+            avg_recall: total_recall / evaluated as f32,
+            avg_ann_count: total_ann as f32 / evaluated as f32,
+            avg_exhaustive_count: total_brute as f32 / evaluated as f32,
+            evaluated,
+        })
     }
 
     fn brute_force_search(
@@ -252,13 +391,23 @@ impl NamespaceInner {
             .collect())
     }
 
-    fn rebuild_ivf(&mut self, metric: DistanceMetric) -> Result<()> {
-        self.ivf = self.build_ivf_index(metric)?;
+    fn rebuild_ivf(
+        &mut self,
+        metric: DistanceMetric,
+        coarse_bits: u8,
+        rerank_bits: u8,
+    ) -> Result<()> {
+        self.ivf = self.build_ivf_index(metric, coarse_bits, rerank_bits)?;
         self.ivf_dirty = false;
         Ok(())
     }
 
-    fn build_ivf_index(&self, metric: DistanceMetric) -> Result<Option<IvfIndex>> {
+    fn build_ivf_index(
+        &self,
+        metric: DistanceMetric,
+        coarse_bits: u8,
+        rerank_bits: u8,
+    ) -> Result<Option<IvfIndex>> {
         let mut rows_with_vectors = Vec::new();
         for row in self.rows.values() {
             let Some(vector) = row.vector.as_ref() else {
@@ -294,6 +443,18 @@ impl NamespaceInner {
             return Ok(None);
         }
 
+        if coarse_bits == 0 {
+            return Err(anyhow!("coarse bits must be > 0"));
+        }
+        if rerank_bits == 0 {
+            return Err(anyhow!("rerank bits must be > 0"));
+        }
+        if rerank_bits < coarse_bits {
+            return Err(anyhow!(
+                "rerank bits ({rerank_bits}) must be >= coarse bits ({coarse_bits})"
+            ));
+        }
+
         let params = TrainParams {
             nlist,
             max_iterations: IVF_MAX_ITERATIONS,
@@ -311,7 +472,29 @@ impl NamespaceInner {
             }
         }
 
-        Ok(Some(IvfIndex::new(model, postings, metric, dim)))
+        let erq_model = erq::train(
+            &samples,
+            ErqTrainConfig {
+                coarse_bits,
+                fine_bits: rerank_bits,
+            },
+        )?;
+        let mut encodings: HashMap<String, ErqEncodedVector> = HashMap::new();
+        for (id, vector) in rows_with_vectors.iter() {
+            let encoding = erq_model.encode(vector)?;
+            encodings.insert(id.clone(), encoding);
+        }
+
+        Ok(Some(IvfIndex::new(
+            model,
+            postings,
+            metric,
+            dim,
+            erq_model,
+            encodings,
+            coarse_bits,
+            rerank_bits,
+        )))
     }
 }
 
@@ -329,21 +512,41 @@ struct IvfIndex {
     postings: Vec<Vec<String>>,
     metric: DistanceMetric,
     dimension: usize,
+    erq: ErqModel,
+    encodings: HashMap<String, ErqEncodedVector>,
+    coarse_bits: u8,
+    rerank_bits: u8,
 }
 
 impl IvfIndex {
+    #[allow(clippy::too_many_arguments)]
     fn new(
         model: IvfModel,
         postings: Vec<Vec<String>>,
         metric: DistanceMetric,
         dimension: usize,
+        erq: ErqModel,
+        encodings: HashMap<String, ErqEncodedVector>,
+        coarse_bits: u8,
+        rerank_bits: u8,
     ) -> Self {
         Self {
             model,
             postings,
             metric,
             dimension,
+            erq,
+            encodings,
+            coarse_bits,
+            rerank_bits,
         }
+    }
+
+    fn matches(&self, metric: DistanceMetric, coarse_bits: u8, rerank_bits: u8) -> bool {
+        self.metric == metric
+            && self.dimension > 0
+            && self.coarse_bits == coarse_bits
+            && self.rerank_bits == rerank_bits
     }
 
     fn search(
@@ -378,43 +581,66 @@ impl IvfIndex {
         }
 
         let probes = self.model.probe_order(query, nprobe)?;
-        let mut candidates: Vec<(f32, &Row)> = Vec::new();
+        let mut coarse_candidates: Vec<(f32, &Row)> = Vec::new();
         for assignment in probes {
             if let Some(list) = self.postings.get(assignment.list_id) {
                 for id in list {
                     let Some(row) = rows.get(id) else { continue };
+                    let Some(encoding) = self.encodings.get(id) else {
+                        continue;
+                    };
+                    let coarse_distance = self.erq.coarse_distance(
+                        query,
+                        encoding.coarse(),
+                        to_erq_metric(metric),
+                    )?;
+                    coarse_candidates.push((coarse_distance, row));
+                }
+            }
+        }
+
+        if coarse_candidates.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        coarse_candidates.sort_by(|a, b| match a.0.partial_cmp(&b.0) {
+            Some(Ordering::Equal) | None => a.1.id.cmp(&b.1.id),
+            Some(ordering) => ordering,
+        });
+
+        let candidate_budget = ann.candidate_budget(top_k).max(top_k);
+        coarse_candidates.truncate(candidate_budget);
+
+        let mut hits = Vec::new();
+        for (_, row) in coarse_candidates.into_iter() {
+            let Some(encoding) = self.encodings.get(&row.id) else {
+                continue;
+            };
+            let score = match ann.rerank_mode {
+                RerankMode::Erq => {
+                    self.erq
+                        .fine_distance(query, encoding, to_erq_metric(metric))?
+                }
+                RerankMode::Fp32 => {
                     let Some(vector) = row.vector.as_ref() else {
                         continue;
                     };
                     if vector.len() != query.len() {
                         continue;
                     }
-                    let distance = metric.distance(query, vector)?;
-                    candidates.push((distance, row));
+                    metric.distance(query, vector)?
                 }
-            }
-        }
-
-        if candidates.is_empty() {
-            return Ok(Vec::new());
-        }
-
-        candidates.sort_by(
-            |a, b| match a.0.partial_cmp(&b.0).unwrap_or(Ordering::Equal) {
-                Ordering::Equal => a.1.id.cmp(&b.1.id),
-                other => other,
-            },
-        );
-        candidates.truncate(top_k);
-
-        Ok(candidates
-            .into_iter()
-            .map(|(score, row)| QueryHit {
+            };
+            hits.push(QueryHit {
                 id: row.id.clone(),
                 score,
                 attributes: row.attributes.clone(),
-            })
-            .collect())
+            });
+        }
+
+        hits.sort_by(compare_hits);
+        hits.truncate(top_k);
+        Ok(hits)
     }
 }
 
@@ -422,6 +648,20 @@ fn to_ivf_metric(metric: DistanceMetric) -> ivf::DistanceMetric {
     match metric {
         DistanceMetric::Cosine => ivf::DistanceMetric::Cosine,
         DistanceMetric::EuclideanSquared => ivf::DistanceMetric::EuclideanSquared,
+    }
+}
+
+fn to_erq_metric(metric: DistanceMetric) -> ErqDistanceMetric {
+    match metric {
+        DistanceMetric::Cosine => ErqDistanceMetric::Cosine,
+        DistanceMetric::EuclideanSquared => ErqDistanceMetric::EuclideanSquared,
+    }
+}
+
+fn compare_hits(a: &QueryHit, b: &QueryHit) -> Ordering {
+    match a.score.partial_cmp(&b.score) {
+        Some(Ordering::Equal) | None => a.id.cmp(&b.id),
+        Some(ordering) => ordering,
     }
 }
 
@@ -539,6 +779,10 @@ pub struct AnnParams {
     pub use_ivf: bool,
     pub target_recall: f32,
     pub nprobe: Option<usize>,
+    pub rerank_scale: usize,
+    pub rerank_mode: RerankMode,
+    pub coarse_bits: Option<u8>,
+    pub rerank_bits: Option<u8>,
 }
 
 impl Default for AnnParams {
@@ -547,8 +791,39 @@ impl Default for AnnParams {
             use_ivf: true,
             target_recall: 0.1,
             nprobe: None,
+            rerank_scale: 5,
+            rerank_mode: RerankMode::Erq,
+            coarse_bits: None,
+            rerank_bits: None,
         }
     }
+}
+
+impl AnnParams {
+    fn fill_defaults(&mut self) {
+        if self.coarse_bits.is_none() {
+            self.coarse_bits = Some(ERQ_DEFAULT_COARSE_BITS);
+        }
+        if self.rerank_bits.is_none() {
+            self.rerank_bits = Some(ERQ_DEFAULT_RERANK_BITS);
+        }
+    }
+
+    fn candidate_budget(&self, top_k: usize) -> usize {
+        if self.rerank_scale == 0 {
+            top_k
+        } else {
+            top_k.saturating_mul(self.rerank_scale)
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum RerankMode {
+    #[default]
+    Erq,
+    Fp32,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -578,6 +853,48 @@ pub struct QueryHit {
     pub attributes: Option<serde_json::Value>,
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct RecallRequest {
+    pub namespace: String,
+    #[serde(default = "default_recall_num")]
+    pub num: usize,
+    #[serde(default = "default_recall_top_k")]
+    pub top_k: usize,
+    #[serde(default)]
+    pub queries: Option<Vec<Vec<f32>>>,
+    #[serde(default)]
+    pub ann_params: AnnParams,
+    #[serde(default)]
+    pub metric: Option<DistanceMetric>,
+}
+
+fn default_recall_num() -> usize {
+    10
+}
+
+fn default_recall_top_k() -> usize {
+    10
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct RecallResponse {
+    pub avg_recall: f32,
+    pub avg_ann_count: f32,
+    pub avg_exhaustive_count: f32,
+    pub evaluated: usize,
+}
+
+impl RecallResponse {
+    fn empty() -> Self {
+        Self {
+            avg_recall: 0.0,
+            avg_ann_count: 0.0,
+            avg_exhaustive_count: 0.0,
+            evaluated: 0,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -601,6 +918,18 @@ mod tests {
             vector: Some(vector.to_vec()),
             attributes: None,
         }
+    }
+
+    #[test]
+    fn ann_params_candidate_budget_scales_with_multiplier() {
+        let params = AnnParams::default();
+        assert_eq!(params.candidate_budget(4), 20);
+
+        let params = AnnParams {
+            rerank_scale: 0,
+            ..AnnParams::default()
+        };
+        assert_eq!(params.candidate_budget(4), 4);
     }
 
     #[tokio::test]
@@ -697,6 +1026,7 @@ mod tests {
                     use_ivf: true,
                     target_recall: 0.2,
                     nprobe: Some(1),
+                    ..Default::default()
                 },
             })
             .await
@@ -707,5 +1037,152 @@ mod tests {
             response.hits[0].id.starts_with("left-"),
             "expected nearest cluster to win"
         );
+    }
+
+    #[tokio::test]
+    async fn query_respects_min_wal_sequence() {
+        let store = sample_store();
+        let registry = NamespaceRegistry::new(store.clone());
+        let pointer = registry
+            .apply_write(WriteBatch {
+                namespace: "ns".to_string(),
+                upserts: vec![doc("a", &[1.0, 0.0])],
+                deletes: Vec::new(),
+            })
+            .await
+            .expect("initial write");
+
+        let err = registry
+            .query(QueryRequest {
+                namespace: "ns".to_string(),
+                vector: vec![1.0, 0.0],
+                top_k: 1,
+                metric: None,
+                min_wal_sequence: Some(pointer.sequence + 1),
+                ann_params: Default::default(),
+            })
+            .await
+            .expect_err("consistency requirement should fail");
+        assert!(err.to_string().contains("consistency level unmet"));
+    }
+
+    #[tokio::test]
+    async fn query_catches_up_with_recent_wal() {
+        let store = sample_store();
+        let registry = NamespaceRegistry::new(store.clone());
+        let first_pointer = registry
+            .apply_write(WriteBatch {
+                namespace: "ns".to_string(),
+                upserts: vec![doc("a", &[1.0, 0.0])],
+                deletes: Vec::new(),
+            })
+            .await
+            .expect("initial write");
+
+        let namespace_store = store.namespace("ns".to_string());
+        let wal_batch = WalBatch {
+            namespace: "ns".to_string(),
+            operations: vec![WriteOp::Upsert {
+                document: doc("b", &[0.0, 1.0]),
+            }],
+        };
+        let second_pointer = namespace_store
+            .append_batch(&wal_batch)
+            .await
+            .expect("external append");
+        assert!(second_pointer.sequence > first_pointer.sequence);
+
+        let response = registry
+            .query(QueryRequest {
+                namespace: "ns".to_string(),
+                vector: vec![0.0, 1.0],
+                top_k: 1,
+                metric: None,
+                min_wal_sequence: Some(second_pointer.sequence),
+                ann_params: Default::default(),
+            })
+            .await
+            .expect("query should reload WAL");
+
+        assert_eq!(response.hits.len(), 1);
+        assert_eq!(response.hits[0].id, "b");
+    }
+
+    #[tokio::test]
+    async fn query_uses_brute_force_when_ivf_disabled() {
+        let store = sample_store();
+        let registry = NamespaceRegistry::new(store);
+        let docs: Vec<Document> = (0..16)
+            .map(|i| {
+                let position = 1.0 + i as f32;
+                doc(&format!("doc-{i}"), &[1.0, position])
+            })
+            .collect();
+        registry
+            .apply_write(WriteBatch {
+                namespace: "ns".to_string(),
+                upserts: docs,
+                deletes: Vec::new(),
+            })
+            .await
+            .expect("bulk write");
+
+        let response = registry
+            .query(QueryRequest {
+                namespace: "ns".to_string(),
+                vector: vec![1.0, 25.0],
+                top_k: 1,
+                metric: None,
+                min_wal_sequence: None,
+                ann_params: AnnParams {
+                    use_ivf: false,
+                    ..Default::default()
+                },
+            })
+            .await
+            .expect("brute-force query");
+
+        assert_eq!(response.hits.len(), 1);
+        assert_eq!(response.hits[0].id, "doc-15");
+    }
+
+    #[tokio::test]
+    async fn debug_recall_reports_full_recall_with_fp32_rerank() {
+        let store = sample_store();
+        let registry = NamespaceRegistry::new(store);
+        let docs: Vec<Document> = (0..12)
+            .map(|i| {
+                let x = i as f32;
+                doc(&format!("doc-{i}"), &[x, 1.0 - x])
+            })
+            .collect();
+        registry
+            .apply_write(WriteBatch {
+                namespace: "ns".to_string(),
+                upserts: docs,
+                deletes: Vec::new(),
+            })
+            .await
+            .expect("seed data");
+
+        let response = registry
+            .debug_recall(RecallRequest {
+                namespace: "ns".to_string(),
+                num: 6,
+                top_k: 3,
+                queries: None,
+                ann_params: AnnParams {
+                    rerank_mode: RerankMode::Fp32,
+                    target_recall: 1.0,
+                    ..Default::default()
+                },
+                metric: None,
+            })
+            .await
+            .expect("recall evaluation");
+
+        assert_eq!(response.evaluated, 6);
+        assert!((response.avg_recall - 1.0).abs() < 1e-6);
+        assert!(response.avg_ann_count >= 3.0);
     }
 }

--- a/crates/elax-erq/src/lib.rs
+++ b/crates/elax-erq/src/lib.rs
@@ -1,8 +1,313 @@
 //! Extended RaBitQ quantization primitives.
 
-use anyhow::Result;
+use anyhow::{ensure, Result};
 
-/// Placeholder quantization routine that echoes the input vector length.
-pub fn encode(vector: &[f32]) -> Result<usize> {
-    Ok(vector.len())
+/// Maximum number of bits supported by the reference encoder.
+pub const MAX_BITS: u8 = 16;
+
+/// Training configuration describing the bit budgets for the coarse and rerank paths.
+#[derive(Clone, Copy, Debug)]
+pub struct TrainConfig {
+    pub coarse_bits: u8,
+    pub fine_bits: u8,
+}
+
+impl Default for TrainConfig {
+    fn default() -> Self {
+        Self {
+            coarse_bits: 1,
+            fine_bits: 8,
+        }
+    }
+}
+
+/// Distance metric supported by the ERQ distance estimators.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DistanceMetric {
+    Cosine,
+    EuclideanSquared,
+}
+
+/// Learned ERQ model storing per-dimension quantization ranges.
+#[derive(Clone, Debug)]
+pub struct Model {
+    dimension: usize,
+    coarse_bits: u8,
+    fine_bits: u8,
+    mins: Vec<f32>,
+    maxs: Vec<f32>,
+}
+
+impl Model {
+    /// Encode a floating point vector into coarse/fine ERQ codes.
+    pub fn encode(&self, vector: &[f32]) -> Result<EncodedVector> {
+        ensure!(
+            vector.len() == self.dimension,
+            "vector dimension mismatch: {} vs {}",
+            vector.len(),
+            self.dimension
+        );
+        let fine = self.quantize(vector, self.fine_bits)?;
+        let coarse = self.downsample(&fine);
+        Ok(EncodedVector { coarse, fine })
+    }
+
+    /// Compute the distance between the query and the coarse reconstruction.
+    pub fn coarse_distance(
+        &self,
+        query: &[f32],
+        coarse: &[u8],
+        metric: DistanceMetric,
+    ) -> Result<f32> {
+        ensure!(
+            coarse.len() == self.dimension,
+            "coarse code dimension mismatch: {} vs {}",
+            coarse.len(),
+            self.dimension
+        );
+        let approx = self.dequantize(coarse, self.coarse_bits);
+        distance(metric, query, &approx)
+    }
+
+    /// Compute the distance between the query and the fine reconstruction.
+    pub fn fine_distance(
+        &self,
+        query: &[f32],
+        encoded: &EncodedVector,
+        metric: DistanceMetric,
+    ) -> Result<f32> {
+        ensure!(
+            encoded.fine.len() == self.dimension,
+            "fine code dimension mismatch: {} vs {}",
+            encoded.fine.len(),
+            self.dimension
+        );
+        let approx = self.dequantize(&encoded.fine, self.fine_bits);
+        distance(metric, query, &approx)
+    }
+
+    /// Dimensionality of vectors supported by the model.
+    pub fn dimension(&self) -> usize {
+        self.dimension
+    }
+
+    /// Number of bits allocated to the coarse (x-bit) scan.
+    pub fn coarse_bits(&self) -> u8 {
+        self.coarse_bits
+    }
+
+    /// Number of bits allocated to the rerank (y-bit) path.
+    pub fn fine_bits(&self) -> u8 {
+        self.fine_bits
+    }
+
+    fn quantize(&self, vector: &[f32], bits: u8) -> Result<Vec<u8>> {
+        let levels = 1u32 << bits;
+        let mut codes = Vec::with_capacity(vector.len());
+        for (idx, &value) in vector.iter().enumerate() {
+            let min = self.mins[idx];
+            let max = self.maxs[idx];
+            if max <= min {
+                codes.push(0);
+                continue;
+            }
+            let normalized = ((value - min) / (max - min)).clamp(0.0, 1.0);
+            let level = (normalized * (levels - 1) as f32).round() as u32;
+            codes.push(level.min(levels - 1) as u8);
+        }
+        Ok(codes)
+    }
+
+    fn downsample(&self, fine: &[u8]) -> Vec<u8> {
+        let fine_levels = 1u32 << self.fine_bits;
+        let coarse_levels = 1u32 << self.coarse_bits;
+        fine.iter()
+            .map(|&code| {
+                let scaled = (code as u32 * coarse_levels) / fine_levels;
+                scaled.min(coarse_levels - 1) as u8
+            })
+            .collect()
+    }
+
+    fn dequantize(&self, codes: &[u8], bits: u8) -> Vec<f32> {
+        let levels = 1u32 << bits;
+        let denom = (levels - 1).max(1) as f32;
+        codes
+            .iter()
+            .enumerate()
+            .map(|(idx, &code)| {
+                let min = self.mins[idx];
+                let max = self.maxs[idx];
+                if max <= min {
+                    return min;
+                }
+                min + (code as f32 / denom) * (max - min)
+            })
+            .collect()
+    }
+}
+
+/// Train an ERQ model using per-dimension min/max ranges derived from the samples.
+pub fn train(samples: &[Vec<f32>], config: TrainConfig) -> Result<Model> {
+    ensure!(!samples.is_empty(), "training samples must not be empty");
+    ensure!(config.coarse_bits > 0, "coarse bits must be > 0");
+    ensure!(config.fine_bits > 0, "fine bits must be > 0");
+    ensure!(
+        config.coarse_bits <= config.fine_bits,
+        "fine bits must be >= coarse bits"
+    );
+    ensure!(config.coarse_bits <= MAX_BITS, "coarse bits exceed support");
+    ensure!(config.fine_bits <= MAX_BITS, "fine bits exceed support");
+
+    let dimension = samples[0].len();
+    ensure!(dimension > 0, "sample dimension must be > 0");
+    for (idx, sample) in samples.iter().enumerate() {
+        ensure!(
+            sample.len() == dimension,
+            "sample {idx} dimension mismatch: {} vs {}",
+            sample.len(),
+            dimension
+        );
+    }
+
+    let mut mins = vec![f32::INFINITY; dimension];
+    let mut maxs = vec![f32::NEG_INFINITY; dimension];
+    for sample in samples {
+        for (idx, &value) in sample.iter().enumerate() {
+            if value < mins[idx] {
+                mins[idx] = value;
+            }
+            if value > maxs[idx] {
+                maxs[idx] = value;
+            }
+        }
+    }
+
+    for idx in 0..dimension {
+        if !mins[idx].is_finite() || !maxs[idx].is_finite() {
+            mins[idx] = 0.0;
+            maxs[idx] = 0.0;
+        }
+    }
+
+    Ok(Model {
+        dimension,
+        coarse_bits: config.coarse_bits,
+        fine_bits: config.fine_bits,
+        mins,
+        maxs,
+    })
+}
+
+/// Encoded representation storing coarse and fine quantization codes.
+#[derive(Clone, Debug)]
+pub struct EncodedVector {
+    coarse: Vec<u8>,
+    fine: Vec<u8>,
+}
+
+impl EncodedVector {
+    pub fn coarse(&self) -> &[u8] {
+        &self.coarse
+    }
+
+    pub fn fine(&self) -> &[u8] {
+        &self.fine
+    }
+}
+
+fn distance(metric: DistanceMetric, query: &[f32], approx: &[f32]) -> Result<f32> {
+    ensure!(
+        query.len() == approx.len(),
+        "distance dimension mismatch: {} vs {}",
+        query.len(),
+        approx.len()
+    );
+    match metric {
+        DistanceMetric::Cosine => cosine_distance(query, approx),
+        DistanceMetric::EuclideanSquared => euclidean_squared(query, approx),
+    }
+}
+
+fn cosine_distance(a: &[f32], b: &[f32]) -> Result<f32> {
+    let mut dot = 0.0;
+    let mut norm_a = 0.0;
+    let mut norm_b = 0.0;
+    for i in 0..a.len() {
+        dot += a[i] * b[i];
+        norm_a += a[i] * a[i];
+        norm_b += b[i] * b[i];
+    }
+    if norm_a == 0.0 || norm_b == 0.0 {
+        return Ok(1.0);
+    }
+    Ok(1.0 - dot / (norm_a.sqrt() * norm_b.sqrt()))
+}
+
+fn euclidean_squared(a: &[f32], b: &[f32]) -> Result<f32> {
+    let mut sum = 0.0;
+    for i in 0..a.len() {
+        let diff = a[i] - b[i];
+        sum += diff * diff;
+    }
+    Ok(sum)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn train_and_encode_round_trips_reasonably() {
+        let samples = vec![
+            vec![1.0, -1.0, 0.5],
+            vec![0.5, -0.5, 0.25],
+            vec![0.0, 0.25, -0.25],
+        ];
+        let model = train(&samples, TrainConfig::default()).expect("train");
+        let encoded = model.encode(&samples[0]).expect("encode");
+        assert_eq!(encoded.coarse().len(), 3);
+        assert_eq!(encoded.fine().len(), 3);
+        let coarse = model
+            .coarse_distance(
+                &samples[0],
+                encoded.coarse(),
+                DistanceMetric::EuclideanSquared,
+            )
+            .expect("coarse distance");
+        let fine = model
+            .fine_distance(&samples[0], &encoded, DistanceMetric::EuclideanSquared)
+            .expect("fine distance");
+        assert!(coarse <= fine + 1e-6);
+        assert!(fine <= 1e-4);
+    }
+
+    #[test]
+    fn respects_bit_configuration() {
+        let samples = vec![vec![0.0, 1.0], vec![1.0, 0.0]];
+        let model = train(
+            &samples,
+            TrainConfig {
+                coarse_bits: 2,
+                fine_bits: 4,
+            },
+        )
+        .expect("train");
+        assert_eq!(model.coarse_bits(), 2);
+        assert_eq!(model.fine_bits(), 4);
+        let encoded = model.encode(&samples[1]).expect("encode");
+        assert!(encoded.coarse().iter().all(|&c| c < 4));
+        assert!(encoded.fine().iter().all(|&c| c < 16));
+    }
+
+    #[test]
+    fn distance_handles_constant_dimensions() {
+        let samples = vec![vec![1.0, 1.0], vec![1.0, 1.0]];
+        let model = train(&samples, TrainConfig::default()).expect("train");
+        let encoded = model.encode(&samples[0]).expect("encode");
+        let dist = model
+            .fine_distance(&[1.0, 1.0], &encoded, DistanceMetric::Cosine)
+            .expect("distance");
+        assert!(dist.abs() <= 1e-6);
+    }
 }

--- a/crates/elax-indexer/Cargo.toml
+++ b/crates/elax-indexer/Cargo.toml
@@ -9,3 +9,8 @@ rust-version.workspace = true
 [dependencies]
 anyhow = "1"
 elax-store = { path = "../elax-store" }
+metrics = "0.21"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+tempfile = "3"

--- a/crates/elax-indexer/src/lib.rs
+++ b/crates/elax-indexer/src/lib.rs
@@ -1,11 +1,318 @@
-//! Background indexer and compaction workflows.
+//! Background indexer and compaction workflows for materializing parts.
 
-use anyhow::Result;
-use elax_store::{LocalStore, RouterState};
+use std::{
+    sync::atomic::{AtomicU64, Ordering},
+    time::{Instant, SystemTime, UNIX_EPOCH},
+};
 
-/// Placeholder indexer harness that currently touches router state to prove wiring.
+use anyhow::{Context, Result};
+use elax_store::{LocalStore, PartManifest, RouterState};
+use metrics::{counter, histogram};
+
+static PART_COUNTER: AtomicU64 = AtomicU64::new(1);
+
+/// Configuration values controlling part sizing and retention.
+#[derive(Debug, Clone)]
+pub struct IndexerConfig {
+    pub rows_per_part: usize,
+    pub max_active_parts: usize,
+}
+
+impl Default for IndexerConfig {
+    fn default() -> Self {
+        Self {
+            rows_per_part: 256,
+            max_active_parts: 4,
+        }
+    }
+}
+
+/// Result of a single indexer run.
+#[derive(Debug, Clone)]
+pub struct RunResult {
+    pub router: RouterState,
+    pub processed_batches: usize,
+    pub parts_created: usize,
+    pub compactions: usize,
+}
+
+impl RunResult {
+    pub fn did_work(&self) -> bool {
+        self.processed_batches > 0 || self.parts_created > 0 || self.compactions > 0
+    }
+}
+
+/// Indexer encapsulation that processes namespace WAL data into parts.
+#[derive(Clone)]
+pub struct Indexer {
+    store: LocalStore,
+    config: IndexerConfig,
+}
+
+impl Indexer {
+    pub fn new(store: LocalStore, config: IndexerConfig) -> Self {
+        Self { store, config }
+    }
+
+    /// Process new WAL batches and compact parts if necessary.
+    pub async fn run_once(&self, namespace: &str) -> Result<RunResult> {
+        let timer = Instant::now();
+        let ns_store = self.store.namespace(namespace.to_string());
+        let mut router = ns_store.load_router().await?;
+        let mut batches = ns_store
+            .load_batches_since(router.indexed_wal + 1)
+            .await
+            .with_context(|| format!("loading WAL for namespace {namespace}"))?;
+        batches.retain(|(pointer, _)| pointer.sequence > router.indexed_wal);
+
+        let mut processed_batches = 0usize;
+        let mut parts_created = 0usize;
+        let mut last_sequence = router.indexed_wal;
+        let mut bucket_rows = 0usize;
+        let mut bucket_start: Option<u64> = None;
+
+        for (pointer, batch) in batches.into_iter() {
+            processed_batches += 1;
+            if batch.operations.is_empty() {
+                continue;
+            }
+            last_sequence = pointer.sequence;
+            bucket_rows += batch.operations.len();
+            if bucket_start.is_none() {
+                bucket_start = Some(pointer.sequence);
+            }
+            if bucket_rows >= self.config.rows_per_part {
+                let manifest = self
+                    .flush_part(
+                        namespace,
+                        &ns_store,
+                        bucket_start.unwrap_or(pointer.sequence),
+                        pointer.sequence,
+                        bucket_rows,
+                    )
+                    .await?;
+                parts_created += 1;
+                router.parts.push(manifest);
+                bucket_rows = 0;
+                bucket_start = None;
+            }
+        }
+
+        if bucket_rows > 0 {
+            let start_seq = bucket_start.unwrap_or(last_sequence.max(router.indexed_wal));
+            let manifest = self
+                .flush_part(namespace, &ns_store, start_seq, last_sequence, bucket_rows)
+                .await?;
+            parts_created += 1;
+            router.parts.push(manifest);
+        }
+
+        let mut router_dirty = false;
+        if parts_created > 0 {
+            router.parts.sort_by_key(|part| part.wal_start);
+            router_dirty = true;
+        }
+        if processed_batches > 0 {
+            router.indexed_wal = last_sequence.max(router.indexed_wal);
+            router.epoch = router.epoch.saturating_add(1);
+            router.updated_at = current_millis();
+            router_dirty = true;
+        }
+        if router_dirty {
+            ns_store.store_router(&router).await?;
+        }
+
+        let compactions = self
+            .maybe_compact(namespace, &ns_store, &mut router)
+            .await?;
+
+        if compactions > 0 {
+            ns_store.store_router(&router).await?;
+            counter!(
+                "elax_indexer_compactions_total",
+                compactions as u64,
+                "namespace" => namespace.to_string()
+            );
+        }
+
+        histogram!(
+            "elax_indexer_run_latency_seconds",
+            timer.elapsed().as_secs_f64(),
+            "namespace" => namespace.to_string()
+        );
+
+        Ok(RunResult {
+            router,
+            processed_batches,
+            parts_created,
+            compactions,
+        })
+    }
+
+    /// Continue running the indexer until no additional work remains.
+    pub async fn run_until_idle(&self, namespace: &str) -> Result<RouterState> {
+        loop {
+            let result = self.run_once(namespace).await?;
+            if !result.did_work() {
+                return Ok(result.router);
+            }
+        }
+    }
+
+    async fn flush_part(
+        &self,
+        namespace: &str,
+        ns_store: &elax_store::NamespaceStore,
+        wal_start: u64,
+        wal_end: u64,
+        rows: usize,
+    ) -> Result<PartManifest> {
+        let manifest = PartManifest::new(new_part_id(namespace), wal_start, wal_end, rows);
+        ns_store.write_part_manifest(&manifest).await?;
+        counter!(
+            "elax_indexer_parts_total",
+            1,
+            "namespace" => namespace.to_string(),
+            "stage" => "materialize"
+        );
+        Ok(manifest)
+    }
+
+    async fn maybe_compact(
+        &self,
+        namespace: &str,
+        ns_store: &elax_store::NamespaceStore,
+        router: &mut RouterState,
+    ) -> Result<usize> {
+        if router.parts.len() <= self.config.max_active_parts {
+            return Ok(0);
+        }
+        let mut parts = router.parts.clone();
+        parts.sort_by_key(|p| p.wal_start);
+        let merged_rows: usize = parts.iter().map(|p| p.rows).sum();
+        let merged_start = parts.first().map(|p| p.wal_start).unwrap_or(0);
+        let merged_end = parts
+            .last()
+            .map(|p| p.wal_end)
+            .unwrap_or(router.indexed_wal);
+        let mut merged = PartManifest::new(
+            new_part_id(namespace),
+            merged_start,
+            merged_end,
+            merged_rows,
+        );
+        merged.compacted_from = parts.iter().map(|p| p.id.clone()).collect();
+        ns_store.write_part_manifest(&merged).await?;
+        for part in &parts {
+            ns_store.remove_part_manifest(&part.id).await.ok();
+        }
+        router.parts = vec![merged];
+        router.indexed_wal = merged_end;
+        router.epoch = router.epoch.saturating_add(1);
+        router.updated_at = current_millis();
+        counter!(
+            "elax_indexer_parts_total",
+            1,
+            "namespace" => namespace.to_string(),
+            "stage" => "compact"
+        );
+        Ok(1)
+    }
+}
+
+/// Convenience helper matching the previous Phase 2 API.
 pub async fn run_indexer(store: &LocalStore, namespace: &str) -> Result<RouterState> {
-    let ns_store = store.namespace(namespace.to_string());
-    let router = ns_store.load_router().await?;
-    Ok(router)
+    let indexer = Indexer::new(store.clone(), IndexerConfig::default());
+    indexer.run_until_idle(namespace).await
+}
+
+fn new_part_id(namespace: &str) -> String {
+    let ns = namespace.replace('/', "_");
+    let counter = PART_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_micros();
+    format!("part-{ns}-{timestamp}-{counter:016}")
+}
+
+fn current_millis() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use elax_store::{Document, LocalStore, WalBatch, WriteOp};
+
+    fn temp_store() -> (tempfile::TempDir, LocalStore) {
+        let dir = tempfile::TempDir::new().expect("create temp dir");
+        let store = LocalStore::new(dir.path()).with_fsync(false);
+        (dir, store)
+    }
+
+    fn sample_batch(namespace: &str, seq: u64, rows: usize) -> WalBatch {
+        WalBatch {
+            namespace: namespace.to_string(),
+            operations: (0..rows)
+                .map(|idx| WriteOp::Upsert {
+                    document: Document {
+                        id: format!("doc-{seq}-{idx}"),
+                        vector: Some(vec![idx as f32]),
+                        attributes: None,
+                    },
+                })
+                .collect(),
+        }
+    }
+
+    #[tokio::test]
+    async fn run_once_materializes_parts_and_advances_router() {
+        let (dir, store) = temp_store();
+        let ns = store.namespace("ns");
+        ns.append_batch(&sample_batch("ns", 1, 10))
+            .await
+            .expect("append batch");
+        ns.append_batch(&sample_batch("ns", 2, 10))
+            .await
+            .expect("append batch");
+
+        let indexer = Indexer::new(
+            store.clone(),
+            IndexerConfig {
+                rows_per_part: 8,
+                max_active_parts: 4,
+            },
+        );
+        let result = indexer.run_once("ns").await.expect("run indexer");
+        assert!(result.parts_created >= 1);
+        assert!(result.router.indexed_wal >= 2);
+        let manifests = ns.list_part_manifests().await.expect("list parts");
+        assert!(!manifests.is_empty());
+        drop(dir);
+    }
+
+    #[tokio::test]
+    async fn compaction_merges_parts_when_limit_exceeded() {
+        let (_dir, store) = temp_store();
+        let ns = store.namespace("ns");
+        for seq in 1..=6 {
+            ns.append_batch(&sample_batch("ns", seq, 4))
+                .await
+                .expect("append");
+        }
+        let indexer = Indexer::new(
+            store.clone(),
+            IndexerConfig {
+                rows_per_part: 4,
+                max_active_parts: 2,
+            },
+        );
+        let result = indexer.run_until_idle("ns").await.expect("run indexer");
+        assert_eq!(result.parts.len(), 1);
+        assert!(result.parts[0].compacted_from.len() >= 2);
+    }
 }

--- a/crates/elax-metrics/Cargo.toml
+++ b/crates/elax-metrics/Cargo.toml
@@ -9,3 +9,5 @@ rust-version.workspace = true
 [dependencies]
 anyhow = "1"
 metrics = "0.21"
+metrics-exporter-prometheus = "0.13"
+once_cell = "1"

--- a/crates/elax-metrics/src/lib.rs
+++ b/crates/elax-metrics/src/lib.rs
@@ -1,9 +1,118 @@
-//! Metrics exporters and instrumentation wiring.
+//! Metrics exporters and instrumentation wiring for elacsym components.
 
-use anyhow::Result;
+use std::sync::OnceLock;
 
-/// Placeholder initialization that registers a no-op recorder.
+use anyhow::{anyhow, Result};
+use metrics::{describe_counter, describe_gauge, describe_histogram, Unit};
+use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
+
+static HANDLE: OnceLock<PrometheusHandle> = OnceLock::new();
+
+/// Initialize the global Prometheus recorder if it has not been installed yet.
+///
+/// The recorder is shared across crates and provides a [`PrometheusHandle`] that
+/// can be used to gather metrics snapshots for tests and the `/metrics`
+/// endpoint. Subsequent calls are no-ops.
 pub fn init() -> Result<()> {
-    metrics::register_counter!("elax_placeholder");
+    if HANDLE.get().is_some() {
+        return Ok(());
+    }
+
+    let builder = PrometheusBuilder::new();
+    let handle = builder
+        .install_recorder()
+        .map_err(|err| anyhow!("installing metrics recorder: {err}"))?;
+    register_static_metadata();
+    HANDLE
+        .set(handle)
+        .map_err(|_| anyhow!("metrics recorder already initialized"))?;
     Ok(())
+}
+
+fn register_static_metadata() {
+    describe_counter!(
+        "elax_core_write_requests_total",
+        Unit::Count,
+        "Number of write batches applied per namespace"
+    );
+    describe_histogram!(
+        "elax_core_write_latency_seconds",
+        Unit::Seconds,
+        "Latency distribution for write batches"
+    );
+    describe_counter!(
+        "elax_core_query_requests_total",
+        Unit::Count,
+        "Number of query executions per namespace"
+    );
+    describe_histogram!(
+        "elax_core_query_latency_seconds",
+        Unit::Seconds,
+        "Latency distribution for query execution"
+    );
+    describe_counter!(
+        "elax_cache_hits_total",
+        Unit::Count,
+        "Cache hit count grouped by namespace and asset kind"
+    );
+    describe_counter!(
+        "elax_cache_misses_total",
+        Unit::Count,
+        "Cache miss count grouped by namespace and asset kind"
+    );
+    describe_counter!(
+        "elax_cache_evictions_total",
+        Unit::Count,
+        "Number of cache evictions"
+    );
+    describe_gauge!(
+        "elax_cache_ram_bytes",
+        Unit::Bytes,
+        "Tracked RAM usage of the cache"
+    );
+    describe_gauge!(
+        "elax_core_rows_cached",
+        Unit::Count,
+        "Number of rows currently resident in the namespace state cache"
+    );
+    describe_counter!(
+        "elax_indexer_parts_total",
+        Unit::Count,
+        "Number of parts materialized by the indexer"
+    );
+    describe_counter!(
+        "elax_indexer_compactions_total",
+        Unit::Count,
+        "Number of index compaction operations"
+    );
+    describe_histogram!(
+        "elax_indexer_run_latency_seconds",
+        Unit::Seconds,
+        "Latency distribution for indexer runs"
+    );
+    describe_counter!(
+        "elax_api_requests_total",
+        Unit::Count,
+        "HTTP API request counter grouped by route and status"
+    );
+}
+
+/// Returns the Prometheus handle for metrics exposition if initialization has
+/// completed.
+pub fn handle() -> Option<&'static PrometheusHandle> {
+    HANDLE.get()
+}
+
+/// Gather the current metrics snapshot as text encoded in Prometheus exposition
+/// format.
+pub fn gather() -> Result<String> {
+    let handle = HANDLE
+        .get()
+        .ok_or_else(|| anyhow!("metrics recorder has not been initialized"))?;
+    let rendered = handle.render();
+    if rendered.trim().is_empty() {
+        Ok("# HELP elax_metrics_up Exporter health indicator\n# TYPE elax_metrics_up gauge\nelax_metrics_up 1\n".to_string())
+    } else {
+        Ok(rendered)
+    }
 }


### PR DESCRIPTION
## Summary
- replace the metrics stub with a Prometheus exporter and fallback snapshot so `/metrics` always returns content
- add the NVMe+RAM cache manager, indexer materialization/compaction logic, and store manifest helpers with coverage
- instrument core/api paths with metrics, expose the `/metrics` endpoint, and provide a phase-3 CLI for compaction/verification

## Testing
- cargo fmt --all
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --workspace

------
https://chatgpt.com/codex/tasks/task_e_68ceb2dd4c608332927c12d923c07efa