### PR TITLE
Avoid blocking query runtime in Tantivy directory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,3 +92,7 @@ Legend: `TODO` = not started, `DOING` = in progress, `DONE` = complete.
 
 #### Namespace schema & advanced ERQ capabilities
 - Status: TODO — Persist namespace schemas (attribute types, distance metric, analyzers) and extend the ERQ crate with codebook learning, residual coding, and SIMD kernel dispatch validated by property tests.
+
+#### Tantivy directory runtime isolation
+- Status: DONE — Switch the `ObjectStoreDirectory` to use a dedicated Tokio runtime instead of `Handle::block_on` to avoid panics when invoked from async query handlers.
+- Status: DONE — Add regression coverage exercising the directory from within an active Tokio runtime to ensure reads and writes succeed without blocking the caller's executor.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -736,6 +736,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "elax-cache",
+ "futures",
  "object_store",
  "ownedbytes",
  "serde",

--- a/crates/elax-fts/Cargo.toml
+++ b/crates/elax-fts/Cargo.toml
@@ -16,6 +16,7 @@ object_store = { version = "0.7", default-features = false }
 ownedbytes = "0.6"
 tokio = { version = "1", features = ["rt"] }
 serde_with = "3"
+futures = { version = "0.3", default-features = false, features = ["std", "executor"] }
 
 [dev-dependencies]
 serde_json = "1"


### PR DESCRIPTION
## Summary
- replace direct `Handle::block_on` calls in the Tantivy object store directory with async tasks executed on a dedicated Tokio runtime to avoid nested runtime panics and reuse cached results safely
- add a regression test that exercises directory reads and writes from within an active Tokio runtime, demonstrating the non-blocking behavior
- document the completed runtime isolation workstream in `AGENTS.md` and depend on `futures` to synchronously await spawned tasks

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --workspace`


------
https://chatgpt.com/codex/tasks/task_e_68cff3413dd88332a661d2d36ecd0297