### PR TITLE
Finalize WAL refactor and validate distributed S3 setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,17 @@
+# Agent Task Plan
+
+## Steps
+1. Review existing documentation to understand distributed deployment requirements.
+2. Stand up a local MinIO service for S3-compatible storage.
+3. Configure and launch distributed Elacsym nodes (indexer/query) against MinIO.
+4. Run distributed functionality tests and manual smoke checks; catalog any bugs encountered.
+5. Implement fixes for identified bugs and add corresponding automated tests.
+6. Re-run test suite and document outcomes.
+
+## Progress
+- [x] Step 1
+- [x] Step 2
+- [x] Step 3
+- [x] Step 4
+- [x] Step 5
+- [x] Step 6

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,317 @@
+use std::env;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde::Deserialize;
+
+use crate::namespace::WalConfig;
+use crate::storage::StorageConfig;
+
+/// Top-level application configuration loaded from file + environment.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct AppConfig {
+    pub server: ServerConfig,
+    pub storage: StorageSection,
+    pub cache: CacheSection,
+    pub compaction: CompactionSection,
+    pub logging: LoggingSection,
+    pub distributed: Option<DistributedSection>,
+}
+
+impl AppConfig {
+    /// Load configuration from disk and environment.
+    pub fn load() -> Result<Self> {
+        let config_path = env::var("ELACSYM_CONFIG").unwrap_or_else(|_| "config.toml".to_string());
+
+        let mut builder = config::Config::builder();
+
+        if Path::new(&config_path).exists() {
+            builder = builder.add_source(config::File::from(PathBuf::from(&config_path)));
+        }
+
+        builder = builder.add_source(
+            config::Environment::with_prefix("ELACSYM")
+                .separator("_")
+                .try_parsing(true),
+        );
+
+        let settings = builder.build()?;
+        let mut config: Self = settings.try_deserialize()?;
+
+        // Ensure distributed section exists if node-specific overrides were provided
+        if config.distributed.is_none()
+            && (env::var("ELACSYM_NODE_ID").is_ok() || env::var("ELACSYM_NODE_ROLE").is_ok())
+        {
+            config.distributed = Some(DistributedSection::default());
+        }
+
+        if let Some(dist) = config.distributed.as_mut() {
+            if dist.node_id.is_none() {
+                if let Ok(node_id) = env::var("ELACSYM_NODE_ID") {
+                    dist.node_id = Some(node_id);
+                }
+            }
+            if dist.role.is_none() {
+                if let Ok(role) = env::var("ELACSYM_NODE_ROLE") {
+                    dist.role = Some(role.parse().context("invalid ELACSYM_NODE_ROLE")?);
+                }
+            }
+        }
+
+        Ok(config)
+    }
+
+    /// Resolve storage configuration and associated WAL configuration.
+    pub fn storage_runtime(&self) -> Result<(StorageConfig, WalConfig)> {
+        self.storage.to_runtime()
+    }
+}
+
+impl Default for AppConfig {
+    fn default() -> Self {
+        Self {
+            server: ServerConfig::default(),
+            storage: StorageSection::default(),
+            cache: CacheSection::default(),
+            compaction: CompactionSection::default(),
+            logging: LoggingSection::default(),
+            distributed: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct ServerConfig {
+    pub host: String,
+    pub port: u16,
+}
+
+impl Default for ServerConfig {
+    fn default() -> Self {
+        Self {
+            host: "0.0.0.0".to_string(),
+            port: 3000,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct StorageSection {
+    pub backend: StorageBackendKind,
+    pub local: Option<LocalStorageSection>,
+    pub s3: Option<S3StorageSection>,
+}
+
+impl StorageSection {
+    pub fn to_runtime(&self) -> Result<(StorageConfig, WalConfig)> {
+        match self.backend {
+            StorageBackendKind::Local => {
+                let local = self.local.clone().unwrap_or_default();
+
+                let root_path = local.root_path;
+                let storage_config = StorageConfig::Local {
+                    root_path: root_path.clone(),
+                };
+                let wal_path = PathBuf::from(&root_path).join("wal");
+                Ok((storage_config, WalConfig::local(wal_path)))
+            }
+            StorageBackendKind::S3 => {
+                let s3 = self
+                    .s3
+                    .clone()
+                    .context("storage.s3 configuration required when backend is 's3'")?;
+
+                if s3.bucket.trim().is_empty() {
+                    anyhow::bail!("storage.s3.bucket must be specified");
+                }
+                if s3.region.trim().is_empty() {
+                    anyhow::bail!("storage.s3.region must be specified");
+                }
+
+                let storage_config = StorageConfig::S3 {
+                    bucket: s3.bucket,
+                    region: s3.region,
+                    endpoint: s3.endpoint,
+                };
+                Ok((storage_config, WalConfig::s3()))
+            }
+        }
+    }
+}
+
+impl Default for StorageSection {
+    fn default() -> Self {
+        Self {
+            backend: StorageBackendKind::Local,
+            local: Some(LocalStorageSection::default()),
+            s3: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum StorageBackendKind {
+    Local,
+    S3,
+}
+
+impl Default for StorageBackendKind {
+    fn default() -> Self {
+        StorageBackendKind::Local
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct LocalStorageSection {
+    pub root_path: String,
+}
+
+impl Default for LocalStorageSection {
+    fn default() -> Self {
+        Self {
+            root_path: "./data".to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct S3StorageSection {
+    pub bucket: String,
+    pub region: String,
+    pub endpoint: Option<String>,
+}
+
+impl Default for S3StorageSection {
+    fn default() -> Self {
+        Self {
+            bucket: String::new(),
+            region: String::new(),
+            endpoint: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct CacheSection {
+    pub memory_size: usize,
+    pub disk_size: usize,
+    pub disk_path: String,
+}
+
+impl Default for CacheSection {
+    fn default() -> Self {
+        Self {
+            memory_size: 4 * 1024 * 1024 * 1024,
+            disk_size: 100 * 1024 * 1024 * 1024,
+            disk_path: "./cache".to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct CompactionSection {
+    pub enabled: bool,
+    pub interval_secs: u64,
+    pub max_segments: usize,
+    pub max_total_docs: usize,
+}
+
+impl Default for CompactionSection {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            interval_secs: 3600,
+            max_segments: 100,
+            max_total_docs: 1_000_000,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct LoggingSection {
+    pub level: String,
+    pub format: LogFormat,
+}
+
+impl Default for LoggingSection {
+    fn default() -> Self {
+        Self {
+            level: "info".to_string(),
+            format: LogFormat::Json,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum LogFormat {
+    Json,
+    Text,
+}
+
+impl Default for LogFormat {
+    fn default() -> Self {
+        LogFormat::Json
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct DistributedSection {
+    pub enabled: bool,
+    pub node_id: Option<String>,
+    pub role: Option<DistributedRole>,
+    #[serde(rename = "indexer_cluster")]
+    pub indexer: Option<IndexerClusterSection>,
+}
+
+impl Default for DistributedSection {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            node_id: None,
+            role: None,
+            indexer: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum DistributedRole {
+    Indexer,
+    Query,
+}
+
+impl std::str::FromStr for DistributedRole {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_ascii_lowercase().as_str() {
+            "indexer" => Ok(DistributedRole::Indexer),
+            "query" => Ok(DistributedRole::Query),
+            other => anyhow::bail!("unsupported node role: {}", other),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct IndexerClusterSection {
+    pub nodes: Vec<String>,
+}
+
+impl Default for IndexerClusterSection {
+    fn default() -> Self {
+        Self { nodes: Vec::new() }
+    }
+}

--- a/src/index/fulltext.rs
+++ b/src/index/fulltext.rs
@@ -320,23 +320,20 @@ impl FullTextIndex {
         }
 
         // 1. Create temporary directory for Tantivy
-        let temp_dir = std::env::temp_dir().join(format!(
-            "tantivy_{}_{}",
-            segment_id,
-            uuid::Uuid::new_v4()
-        ));
-        std::fs::create_dir_all(&temp_dir).map_err(|e| {
-            Error::internal(format!("Failed to create temp directory: {}", e))
-        })?;
+        let temp_dir =
+            std::env::temp_dir().join(format!("tantivy_{}_{}", segment_id, uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&temp_dir)
+            .map_err(|e| Error::internal(format!("Failed to create temp directory: {}", e)))?;
 
         // 2. Build index on disk
         let mut index = Self::new_persistent(field_name.clone(), &temp_dir)?;
         index.add_documents(documents)?;
 
         // Ensure all changes are committed
-        index.writer.commit().map_err(|e| {
-            Error::internal(format!("Failed to commit Tantivy index: {}", e))
-        })?;
+        index
+            .writer
+            .commit()
+            .map_err(|e| Error::internal(format!("Failed to commit Tantivy index: {}", e)))?;
 
         // 3. Compress index directory to tarball
         tracing::info!(
@@ -401,13 +398,11 @@ fn compress_directory(dir: &Path) -> Result<Vec<u8>> {
         let mut tar = tar::Builder::new(gz);
 
         // Add all files in directory
-        tar.append_dir_all(".", dir).map_err(|e| {
-            Error::internal(format!("Failed to create tarball: {}", e))
-        })?;
+        tar.append_dir_all(".", dir)
+            .map_err(|e| Error::internal(format!("Failed to create tarball: {}", e)))?;
 
-        tar.finish().map_err(|e| {
-            Error::internal(format!("Failed to finish tarball: {}", e))
-        })?;
+        tar.finish()
+            .map_err(|e| Error::internal(format!("Failed to finish tarball: {}", e)))?;
     } // Drop tar and gz here
 
     Ok(buf)
@@ -418,9 +413,8 @@ fn decompress_tarball(data: &[u8], dest: &Path) -> Result<()> {
     let gz = GzDecoder::new(data);
     let mut tar = tar::Archive::new(gz);
 
-    tar.unpack(dest).map_err(|e| {
-        Error::internal(format!("Failed to extract tarball: {}", e))
-    })?;
+    tar.unpack(dest)
+        .map_err(|e| Error::internal(format!("Failed to extract tarball: {}", e)))?;
 
     Ok(())
 }

--- a/src/index/vector.rs
+++ b/src/index/vector.rs
@@ -230,9 +230,7 @@ impl VectorIndex {
             self.vectors.len(),
             index_bytes.len()
         );
-        storage
-            .put(&index_path, Bytes::from(index_bytes))
-            .await?;
+        storage.put(&index_path, Bytes::from(index_bytes)).await?;
 
         Ok(index_path)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@
 
 pub mod api;
 pub mod cache;
+pub mod config;
 pub mod error;
 pub mod index;
 pub mod manifest;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,89 +1,205 @@
 //! Elacsym server binary
 
-use std::env;
 use std::sync::Arc;
-use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
+use anyhow::{anyhow, Context};
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
+
+use elacsym::api::{create_router, AppState, NodeRole};
 use elacsym::cache::{CacheConfig, CacheManager};
-use elacsym::namespace::NamespaceManager;
-use elacsym::storage::local::LocalStorage;
+use elacsym::config::{AppConfig, DistributedRole, LogFormat};
+use elacsym::namespace::{CompactionConfig, NamespaceManager};
+use elacsym::sharding::{IndexerCluster, NodeConfig};
+use elacsym::storage::create_storage;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    // Initialize tracing
-    tracing_subscriber::registry()
-        .with(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "elacsym=debug,tower_http=debug".into()),
-        )
-        .with(tracing_subscriber::fmt::layer())
-        .init();
+    let config = AppConfig::load().context("failed to load configuration")?;
 
-    // Get storage path from environment or use default
-    let storage_path = env::var("ELACSYM_STORAGE_PATH").unwrap_or_else(|_| "./data".to_string());
+    init_tracing(&config)?;
 
-    tracing::info!("Using storage path: {}", storage_path);
+    // Resolve storage and WAL configuration
+    let (storage_config, wal_config) = config
+        .storage_runtime()
+        .context("invalid storage configuration")?;
 
-    // Create storage backend (local for now)
-    let storage = Arc::new(LocalStorage::new(&storage_path)?);
+    let storage_backend = create_storage(storage_config).await?;
+    let storage: Arc<dyn elacsym::storage::StorageBackend> = Arc::from(storage_backend);
 
-    // Create cache (optional - can be disabled with env var)
-    let cache = if env::var("ELACSYM_DISABLE_CACHE").is_ok() {
-        tracing::info!("Cache disabled by environment variable");
-        None
-    } else {
-        let cache_config = CacheConfig {
-            memory_size: 4 * 1024 * 1024 * 1024, // 4GB
-            disk_size: 100 * 1024 * 1024 * 1024, // 100GB
-            disk_path: env::var("ELACSYM_CACHE_PATH")
-                .unwrap_or_else(|_| "/tmp/elacsym-cache".to_string()),
-        };
+    // Build cache if enabled
+    let cache = build_cache(&config).await?;
 
-        tracing::info!(
-            "Initializing cache: memory={}GB, disk={}GB, path={}",
-            cache_config.memory_size / (1024 * 1024 * 1024),
-            cache_config.disk_size / (1024 * 1024 * 1024),
-            cache_config.disk_path
-        );
+    // Build compaction configuration
+    let compaction_config = build_compaction_config(&config.compaction);
 
-        match CacheManager::new(cache_config).await {
-            Ok(cache) => {
-                tracing::info!("Cache initialized successfully");
-                Some(Arc::new(cache))
-            }
-            Err(e) => {
-                tracing::warn!("Failed to initialize cache: {}. Running without cache.", e);
-                None
-            }
-        }
-    };
+    // Determine node identity
+    let node_id = resolve_node_id(&config);
+    tracing::info!(%node_id, "Starting Elacsym node");
 
-    // Get node ID from environment or use hostname
-    let node_id = env::var("ELACSYM_NODE_ID").unwrap_or_else(|_| {
-        hostname::get()
-            .ok()
-            .and_then(|h| h.into_string().ok())
-            .unwrap_or_else(|| "elacsym-node".to_string())
-    });
+    // Instantiate namespace manager
+    let manager = Arc::new(NamespaceManager::with_compaction_config(
+        storage.clone(),
+        cache.clone(),
+        compaction_config.clone(),
+        wal_config.clone(),
+        node_id.clone(),
+    ));
 
-    tracing::info!("Node ID: {}", node_id);
+    // Determine distributed state
+    let (state, role_description) = build_app_state(&config, manager.clone(), node_id.clone())?;
+    tracing::info!(%role_description, "Node role initialised");
 
-    // Create namespace manager
-    let manager = if let Some(cache) = cache {
-        Arc::new(NamespaceManager::with_cache(storage, cache, node_id))
-    } else {
-        Arc::new(NamespaceManager::new(storage, node_id))
-    };
-
-    // Create API router
-    let app = elacsym::api::create_router(manager);
+    let router = create_router(state);
 
     // Start server
-    let addr = "0.0.0.0:3000";
-    let listener = tokio::net::TcpListener::bind(addr).await?;
-    tracing::info!("Listening on {}", addr);
+    let addr = format!("{}:{}", config.server.host, config.server.port);
+    let listener = tokio::net::TcpListener::bind(&addr)
+        .await
+        .with_context(|| format!("failed to bind to {}", addr))?;
+    tracing::info!(%addr, "Listening for HTTP traffic");
 
-    axum::serve(listener, app).await?;
+    axum::serve(listener, router).await?;
 
     Ok(())
+}
+
+fn resolve_node_id(config: &AppConfig) -> String {
+    config
+        .distributed
+        .as_ref()
+        .and_then(|d| d.node_id.clone())
+        .or_else(|| std::env::var("ELACSYM_NODE_ID").ok())
+        .or_else(|| hostname::get().ok().and_then(|h| h.into_string().ok()))
+        .unwrap_or_else(|| "elacsym-node".to_string())
+}
+
+async fn build_cache(config: &AppConfig) -> anyhow::Result<Option<Arc<CacheManager>>> {
+    if std::env::var("ELACSYM_DISABLE_CACHE").is_ok() {
+        tracing::info!("Cache disabled via environment variable");
+        return Ok(None);
+    }
+
+    if config.cache.memory_size == 0 {
+        tracing::info!("Cache disabled via configuration (memory_size = 0)");
+        return Ok(None);
+    }
+
+    let cache_config = CacheConfig {
+        memory_size: config.cache.memory_size,
+        disk_size: config.cache.disk_size,
+        disk_path: config.cache.disk_path.clone(),
+    };
+
+    tracing::info!(
+        memory_mb = cache_config.memory_size / (1024 * 1024),
+        disk_mb = cache_config.disk_size / (1024 * 1024),
+        path = %cache_config.disk_path,
+        "Initialising cache",
+    );
+
+    match CacheManager::new(cache_config).await {
+        Ok(cache) => Ok(Some(Arc::new(cache))),
+        Err(err) => {
+            tracing::warn!(error = %err, "Failed to initialise cache; continuing without it");
+            Ok(None)
+        }
+    }
+}
+
+fn build_compaction_config(config: &elacsym::config::CompactionSection) -> CompactionConfig {
+    if !config.enabled {
+        return CompactionConfig {
+            interval_secs: 0,
+            max_segments: usize::MAX,
+            max_total_docs: usize::MAX,
+            ..CompactionConfig::default()
+        };
+    }
+
+    CompactionConfig {
+        interval_secs: config.interval_secs,
+        max_segments: config.max_segments,
+        max_total_docs: config.max_total_docs,
+        ..CompactionConfig::default()
+    }
+}
+
+fn init_tracing(config: &AppConfig) -> anyhow::Result<()> {
+    let env_filter = EnvFilter::try_from_default_env()
+        .or_else(|_| EnvFilter::try_new(config.logging.level.clone()))
+        .unwrap_or_else(|_| EnvFilter::new("elacsym=info"));
+
+    let registry = tracing_subscriber::registry().with(env_filter);
+
+    match config.logging.format {
+        LogFormat::Json => {
+            registry
+                .with(tracing_subscriber::fmt::layer().json())
+                .init();
+        }
+        LogFormat::Text => {
+            registry.with(tracing_subscriber::fmt::layer()).init();
+        }
+    }
+
+    Ok(())
+}
+
+fn build_app_state(
+    config: &AppConfig,
+    manager: Arc<NamespaceManager>,
+    node_id: String,
+) -> anyhow::Result<(AppState, &'static str)> {
+    if let Some(distributed) = &config.distributed {
+        if distributed.enabled {
+            let indexer_nodes = distributed
+                .indexer
+                .as_ref()
+                .ok_or_else(|| anyhow!(
+                    "distributed.indexer_cluster.nodes must be specified when distributed mode is enabled"
+                ))?
+                .nodes
+                .clone();
+
+            if indexer_nodes.is_empty() {
+                return Err(anyhow!(
+                    "distributed.indexer_cluster.nodes must contain at least one indexer"
+                ));
+            }
+
+            let dist_role = distributed.role.clone().unwrap_or(DistributedRole::Indexer);
+
+            let (cluster, role, description) = match dist_role {
+                DistributedRole::Indexer => {
+                    let idx = indexer_nodes
+                        .iter()
+                        .position(|n| n == &node_id)
+                        .ok_or_else(|| {
+                            anyhow!(
+                                "node_id '{}' not found in distributed.indexer_cluster.nodes",
+                                node_id
+                            )
+                        })?;
+
+                    let cluster = Arc::new(IndexerCluster::new(
+                        NodeConfig::new(node_id.clone(), indexer_nodes.len(), idx),
+                        indexer_nodes,
+                    ));
+                    (cluster, NodeRole::Indexer, "indexer")
+                }
+                DistributedRole::Query => {
+                    let cluster = Arc::new(IndexerCluster::new(
+                        NodeConfig::new(node_id.clone(), indexer_nodes.len(), 0),
+                        indexer_nodes,
+                    ));
+                    (cluster, NodeRole::Query, "query")
+                }
+            };
+
+            let state = AppState::multi_node(manager, cluster, role);
+            return Ok((state, description));
+        }
+    }
+
+    Ok((AppState::single_node(manager), "single-node"))
 }

--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -132,7 +132,11 @@ impl ManifestManager {
             }
             Err(_) => {
                 // Try legacy manifest.json
-                if self.storage.exists(&Self::legacy_manifest_key(namespace)).await? {
+                if self
+                    .storage
+                    .exists(&Self::legacy_manifest_key(namespace))
+                    .await?
+                {
                     // Migrate from legacy
                     tracing::info!("Migrating namespace '{}' to versioned manifests", namespace);
                     Ok(0) // Will create v1 on next save
@@ -179,7 +183,8 @@ impl ManifestManager {
         let data = Bytes::from(json.into_bytes());
 
         // Read current version (or 0 if not exists)
-        let current_version = self.read_current_version(&manifest.namespace)
+        let current_version = self
+            .read_current_version(&manifest.namespace)
             .await
             .unwrap_or(0);
 

--- a/src/namespace/compaction.rs
+++ b/src/namespace/compaction.rs
@@ -216,6 +216,7 @@ impl Drop for CompactionManager {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::namespace::WalConfig;
     use crate::storage::local::LocalStorage;
     use crate::types::{
         AttributeSchema, AttributeType, AttributeValue, DistanceMetric, Document, FullTextConfig,
@@ -244,10 +245,20 @@ mod tests {
             attributes: HashMap::new(),
         };
 
+        let wal = WalConfig::local(temp_dir.path().join("wal"))
+            .build("test_ns", storage.clone(), "test-node")
+            .await
+            .unwrap();
         let namespace = Arc::new(
-            Namespace::create("test_ns".to_string(), schema, storage, None, "test-node".to_string())
-                .await
-                .unwrap(),
+            Namespace::create(
+                "test_ns".to_string(),
+                schema,
+                storage,
+                None,
+                Arc::new(RwLock::new(wal)),
+            )
+            .await
+            .unwrap(),
         );
 
         let config = CompactionConfig::for_testing();
@@ -286,10 +297,20 @@ mod tests {
             attributes,
         };
 
+        let wal = WalConfig::local(temp_dir.path().join("wal"))
+            .build("test_ns", storage.clone(), "test-node")
+            .await
+            .unwrap();
         let namespace = Arc::new(
-            Namespace::create("test_ns".to_string(), schema, storage, None, "test-node".to_string())
-                .await
-                .unwrap(),
+            Namespace::create(
+                "test_ns".to_string(),
+                schema,
+                storage,
+                None,
+                Arc::new(RwLock::new(wal)),
+            )
+            .await
+            .unwrap(),
         );
 
         // Insert multiple small batches to create many segments
@@ -352,10 +373,20 @@ mod tests {
             attributes: HashMap::new(),
         };
 
+        let wal = WalConfig::local(temp_dir.path().join("wal"))
+            .build("test_ns", storage.clone(), "test-node")
+            .await
+            .unwrap();
         let namespace = Arc::new(
-            Namespace::create("test_ns".to_string(), schema, storage, None, "test-node".to_string())
-                .await
-                .unwrap(),
+            Namespace::create(
+                "test_ns".to_string(),
+                schema,
+                storage,
+                None,
+                Arc::new(RwLock::new(wal)),
+            )
+            .await
+            .unwrap(),
         );
 
         let config = CompactionConfig::for_testing();

--- a/src/wal/s3.rs
+++ b/src/wal/s3.rs
@@ -77,11 +77,7 @@ impl S3WalManager {
         );
 
         // 4. Write to S3 (atomic operation)
-        tracing::debug!(
-            "Writing WAL entry to {} ({} bytes)",
-            key,
-            buf.len()
-        );
+        tracing::debug!("Writing WAL entry to {} ({} bytes)", key, buf.len());
 
         self.storage.put(&key, Bytes::from(buf)).await?;
 
@@ -110,7 +106,11 @@ impl S3WalManager {
         let mut sorted_files = files;
         sorted_files.sort();
 
-        tracing::debug!("Found {} WAL files for namespace '{}'", sorted_files.len(), self.namespace);
+        tracing::debug!(
+            "Found {} WAL files for namespace '{}'",
+            sorted_files.len(),
+            self.namespace
+        );
 
         Ok(sorted_files)
     }
@@ -127,7 +127,11 @@ impl S3WalManager {
             return Ok(Vec::new());
         }
 
-        tracing::info!("Replaying {} WAL files for namespace '{}'", files.len(), self.namespace);
+        tracing::info!(
+            "Replaying {} WAL files for namespace '{}'",
+            files.len(),
+            self.namespace
+        );
 
         let mut operations = Vec::new();
 
@@ -178,7 +182,10 @@ impl S3WalManager {
 
         // Deserialize operation
         let operation: WalOperation = rmp_serde::from_slice(msg_data).map_err(|e| {
-            Error::internal(format!("Failed to deserialize WAL operation from {}: {}", key, e))
+            Error::internal(format!(
+                "Failed to deserialize WAL operation from {}: {}",
+                key, e
+            ))
         })?;
 
         Ok(operation)
@@ -195,7 +202,11 @@ impl S3WalManager {
             return Ok(());
         }
 
-        tracing::info!("Truncating {} WAL files for namespace '{}'", files.len(), self.namespace);
+        tracing::info!(
+            "Truncating {} WAL files for namespace '{}'",
+            files.len(),
+            self.namespace
+        );
 
         // Delete all WAL files for this namespace
         for file_key in files {

--- a/tests/wal_recovery_test.rs
+++ b/tests/wal_recovery_test.rs
@@ -1,9 +1,10 @@
-use elacsym::namespace::Namespace;
+use elacsym::namespace::{Namespace, WalConfig};
 use elacsym::storage::local::LocalStorage;
 use elacsym::types::{AttributeValue, DistanceMetric, Document, FullTextConfig, Schema};
 use std::collections::HashMap;
 use std::sync::Arc;
 use tempfile::TempDir;
+use tokio::sync::RwLock;
 
 #[tokio::test]
 async fn test_wal_recovery_after_crash() {
@@ -59,12 +60,19 @@ async fn test_wal_recovery_after_crash() {
 
     // Create namespace
     let storage = Arc::new(LocalStorage::new(storage_path.clone()).unwrap());
+    let wal_base = storage_path.join("wal");
+    let wal_handle = Arc::new(RwLock::new(
+        WalConfig::local(wal_base.clone())
+            .build(&namespace_name, storage.clone(), "test-node")
+            .await
+            .unwrap(),
+    ));
     let namespace = Namespace::create(
         namespace_name.clone(),
         schema.clone(),
         storage.clone(),
         None,
-        "test-node".to_string(),
+        wal_handle,
     )
     .await
     .unwrap();
@@ -74,7 +82,7 @@ async fn test_wal_recovery_after_crash() {
     {
         use elacsym::wal::WalManager;
 
-        let wal_dir = format!("wal/{}", namespace_name);
+        let wal_dir = wal_base.join(&namespace_name);
         let mut wal = WalManager::new(&wal_dir).await.unwrap();
 
         // Write operation to WAL
@@ -93,8 +101,14 @@ async fn test_wal_recovery_after_crash() {
     drop(namespace);
 
     // Step 2: Reload namespace - WAL should be replayed
-    let storage2 = Arc::new(LocalStorage::new(storage_path).unwrap());
-    let namespace2 = Namespace::load(namespace_name, storage2, None, "test-node".to_string())
+    let storage2 = Arc::new(LocalStorage::new(storage_path.clone()).unwrap());
+    let wal_handle = Arc::new(RwLock::new(
+        WalConfig::local(wal_base)
+            .build(&namespace_name, storage2.clone(), "test-node")
+            .await
+            .unwrap(),
+    ));
+    let namespace2 = Namespace::load(namespace_name, storage2, None, wal_handle)
         .await
         .unwrap();
 
@@ -136,9 +150,22 @@ async fn test_wal_empty_after_successful_upsert() {
 
     // Create namespace
     let storage = Arc::new(LocalStorage::new(storage_path.clone()).unwrap());
-    let namespace = Namespace::create("test_wal_truncate".to_string(), schema, storage, None, "test-node".to_string())
-        .await
-        .unwrap();
+    let wal_base = storage_path.join("wal");
+    let wal_handle = Arc::new(RwLock::new(
+        WalConfig::local(wal_base.clone())
+            .build("test_wal_truncate", storage.clone(), "test-node")
+            .await
+            .unwrap(),
+    ));
+    let namespace = Namespace::create(
+        "test_wal_truncate".to_string(),
+        schema,
+        storage,
+        None,
+        wal_handle,
+    )
+    .await
+    .unwrap();
 
     // Upsert documents (should write WAL and then truncate)
     let documents = vec![Document {
@@ -153,7 +180,7 @@ async fn test_wal_empty_after_successful_upsert() {
     // We can check by trying to load - if WAL had entries, they would be replayed
     // Since we just successfully upserted, WAL should be truncated and empty
     use elacsym::wal::WalManager;
-    let wal_dir = "wal/test_wal_truncate";
+    let wal_dir = wal_base.join("test_wal_truncate");
     let wal = WalManager::new(&wal_dir).await.unwrap();
     let entries = wal.read_all().await.unwrap();
     assert_eq!(


### PR DESCRIPTION
## Summary
- add the new `AppConfig` loader and `WalConfig` abstraction so namespaces can build local or S3 WAL backends
- remove the lingering `node_id` parameter on namespaces and update examples/tests to construct WAL handles with the helper
- record plan progress and exercise the MinIO-backed distributed deployment manually to confirm end-to-end routing

## Testing
- cargo test
- manual distributed run against local MinIO (two indexers + one query node)

------
https://chatgpt.com/codex/tasks/task_e_68e3ec281bdc833282b96145ecbad1a6